### PR TITLE
Update references in documentation to "CMakePackagingProject" to use "CMaize"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14) # b/c of FetchContent_MakeAvailable
-project(CMakePP VERSION 1.0.0)
+project(CMaize VERSION 1.0.0)
 
 option(BUILD_TESTING "Should we build and run the unit tests?" OFF)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-CMakePackagingProject
-=====================
+CMaize
+======
 
-[![Documentation Status](https://readthedocs.org/projects/cmakepackagingproject/badge/?version=latest)](https://cmakepackagingproject.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/cmaize/badge/?version=latest)](https://cmaize.readthedocs.io/en/latest/?badge=latest)
 
-CMakePackagingProject is the top-level project of the CMakePP organization. It
-is this project which package maintainers should use to write their projects'
-build systems. Consequently, the CMakePackagingProject's documentation is the
-documentation to consult for generic help when it comes to building a project
-that uses CMakePP.
+CMaize is the top-level project of the CMakePP organization. It is this project
+which package maintainers should use to write their projects' build systems.
+Consequently, CMaize's documentation is the documentation to consult for
+generic help when it comes to building a project that uses CMakePP.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = CMakePP
+SPHINXPROJ    = CMaize
 SOURCEDIR     = src
 BUILDDIR      = build
 

--- a/docs/src/build_system/index.rst
+++ b/docs/src/build_system/index.rst
@@ -1,11 +1,11 @@
-############################################
-Using CMakePP as Your Project's Build System
-############################################
+###########################################
+Using CMaize as Your Project's Build System
+###########################################
 
-The topics in this part focus on how to use CMakePP as your C/C++ project's
+The topics in this part focus on how to use CMaize as your C/C++ project's
 build system.
 
 .. toctree::
    :maxdepth: 2
 
-   obtaining_cmakepp
+   obtaining_cmaize

--- a/docs/src/build_system/obtaining_cmaize.rst
+++ b/docs/src/build_system/obtaining_cmaize.rst
@@ -1,9 +1,9 @@
-***********************************************
-Automatically Downloading and Including CMakePP
-***********************************************
+**********************************************
+Automatically Downloading and Including CMaize
+**********************************************
 
 As a convenience to your users you can make it so that your build system
-automatically downloads CMakePP and includes it. The easiest way to do this is
+automatically downloads CMaize and includes it. The easiest way to do this is
 to put the following CMake script in a file ``cmake/get_cpp.cmake``:
 
 .. code-block:: cmake
@@ -11,10 +11,10 @@ to put the following CMake script in a file ``cmake/get_cpp.cmake``:
    include_guard()
 
    #[[
-   # This function encapsulates the process of getting CMakePP using CMake's
+   # This function encapsulates the process of getting CMaize using CMake's
    # FetchContent module. We have encapsulated it in a function so we can set
    # the options for its configure step without affecting the options for the
-   # parent project's configure step (namely we do not want to build CMakePP's
+   # parent project's configure step (namely we do not want to build CMaize's
    # unit tests).
    #]]
    function(get_cpp)
@@ -23,7 +23,7 @@ to put the following CMake script in a file ``cmake/get_cpp.cmake``:
        set(build_testing_old "${BUILD_TESTING}")
        set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 
-       # Download CMakePP and bring it into scope
+       # Download CMaize and bring it into scope
        include(FetchContent)
        FetchContent_Declare(
             cpp
@@ -35,10 +35,10 @@ to put the following CMake script in a file ``cmake/get_cpp.cmake``:
        set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
    endfunction()
 
-   # Call the function we just wrote to get CMakePP
+   # Call the function we just wrote to get CMaize
    get_cpp()
 
-   # Include CMakePP
+   # Include CMaize
    include(cpp/cpp)
 
 and then in your top level ``CMakeLists.txt`` (assumed to be in the same
@@ -48,6 +48,6 @@ directory as the ``cmake`` directory you put ``get_cpp.cmake`` in) add the line:
 
    include("${PROJECT_SOURCE_DIR}/cmake/get_cpp.cmake")
 
-Your project will now download CMakePP automatically as part of the CMake
-configuration. Users can use an already downloaded CMakePP by setting
-``FETCHCONTENT_SOURCE_DIR_CPP`` to the directory of the pre-downloaded CMakePP.
+Your project will now download CMaize automatically as part of the CMake
+configuration. Users can use an already downloaded CMaize by setting
+``FETCHCONTENT_SOURCE_DIR_CPP`` to the directory of the pre-downloaded CMaize.

--- a/docs/src/build_system/obtaining_cmaize.rst
+++ b/docs/src/build_system/obtaining_cmaize.rst
@@ -27,7 +27,7 @@ to put the following CMake script in a file ``cmake/get_cpp.cmake``:
        include(FetchContent)
        FetchContent_Declare(
             cpp
-            GIT_REPOSITORY https://github.com/CMakePP/CMakePackagingProject
+            GIT_REPOSITORY https://github.com/CMakePP/CMaize
        )
        FetchContent_MakeAvailable(cpp)
 

--- a/docs/src/building/advanced_building.rst
+++ b/docs/src/building/advanced_building.rst
@@ -2,7 +2,7 @@
 Advanced Building
 *****************
 
-While CMakePP strives to make building a project easy, power users and
+While CMaize strives to make building a project easy, power users and
 developers will likely want more control over the project they are building.
 This section highlights some advanced build system features.
 
@@ -25,16 +25,16 @@ users to facilitate building.
 Offline Builds
 ==============
 
-Ultimately when CMakePP can not locate a dependency it will retrieve that
+Ultimately when CMaize can not locate a dependency it will retrieve that
 dependency using CMake's ``FetchContent`` module. In turn, it is possible to
-pre-download dependencies and build a CMakePP project entirely offline. To do
+pre-download dependencies and build a CMaize project entirely offline. To do
 this you will need to set ``FETCHCONTENT_FULLY_DISCONNECTED`` to ``TRUE`` and
 tell CMake where to look for each dependency's source code. For a dependency
 *foo*, set the variable ``FETCHCONTENT_SOURCE_DIR_FOO`` to the path to
 *foo*'s source code.
 
-Developing Across Multiple CMakePP Projects
-===========================================
+Developing Across Multiple CMaize Projects
+==========================================
 
 Say you have two projects *A* and *B* such that *B* uses features in
 *A*. It often is the case that you need to add a feature to *A* to use in

--- a/docs/src/building/cmake_primer.rst
+++ b/docs/src/building/cmake_primer.rst
@@ -26,7 +26,7 @@ Obtaining CMake
 CMake's official website is `here <https://cmake.org/>`_ and contains links
 to download and install the CMake package. CMake is also readily available in
 most package managers.  Most modern packages that rely on CMake require at least
-CMake version 3.0, but you'll need at least version 3.14 to build CMakePP-based
+CMake version 3.0, but you'll need at least version 3.14 to build CMaize-based
 projects.
 
 Building CMake
@@ -56,7 +56,7 @@ Thus in that directory you minimally will need to run:
 
 The ``-H.`` tells CMake to start running in the current directory.  It is
 possible to run CMake from another directory and adjust the path to ``-H``, but
-unless the package maintainer is a CMake guru (or used CMakePP) doing so is
+unless the package maintainer is a CMake guru (or used CMaize) doing so is
 likely to break the build; hence, it is good practice to always run in the same
 directory as the top-level ``CMakeLists.txt`` and just consider the ``-H.`` as
 boilerplate.

--- a/docs/src/building/faqs.rst
+++ b/docs/src/building/faqs.rst
@@ -10,8 +10,8 @@ For private repos CPP_GITHUB_TOKEN must be a valid token
 Cause
 ^^^^^
 
-CMakePP is trying to clone a private GitHub repository and you have not provided
-CMakePP with a valid GitHub authentication token.
+CMaize is trying to clone a private GitHub repository and you have not provided
+CMaize with a valid GitHub authentication token.
 
 Solution
 ^^^^^^^^

--- a/docs/src/building/index.rst
+++ b/docs/src/building/index.rst
@@ -1,9 +1,9 @@
-*********************************************************
-Building a Project Which Uses CMakePP as its Build System
-*********************************************************
+********************************************************
+Building a Project Which Uses CMaize as its Build System
+********************************************************
 
 The topics in this section are intended for use by people who are attempting to
-build a package which uses CMakePP as its build system.
+build a package which uses CMaize as its build system.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/src/building/quick_start.rst
+++ b/docs/src/building/quick_start.rst
@@ -2,18 +2,18 @@
 Quick Start
 ***********
 
-Projects using CMakePP are encouraged to use this page as their build
+Projects using CMaize are encouraged to use this page as their build
 documentation, so if you're seeing this page odds are the package you're trying
-to build uses CMakePP for their build.  If you are a complete CMake newbie
+to build uses CMaize for their build.  If you are a complete CMake newbie
 (there's nothing wrong with that, we all were at some point) check out the
 :ref:`Two-Minute-Introduction-to-CMake` page to get acclimated.
 
-Step 0: Obtain CMakePP
-======================
+Step 0: Obtain CMaize
+=====================
 
-Packages which use CMakePP are encouraged to make their build system download
-CMakePP and include it. If the package you are using does not do this you will
-need to manually download CMakePP yourself and ensure that ``CMAKE_MODULE_PATH``
+Packages which use CMaize are encouraged to make their build system download
+CMaize and include it. If the package you are using does not do this you will
+need to manually download CMaize yourself and ensure that ``CMAKE_MODULE_PATH``
 points to the ``cmake`` directory in the downloaded repository.
 
 Step 1: Build the Project
@@ -21,7 +21,7 @@ Step 1: Build the Project
 
 We'll assume that the source code for the package you are trying to build is
 located in the directory ``package_dir``.  Configuring, building, and installing
-a package which uses CMakePP is done with the following commands:
+a package which uses CMaize is done with the following commands:
 
 .. code-block:: bash
 
@@ -41,7 +41,7 @@ if you need to rerun the `cmake` command.
 Troubleshooting
 ===============
 
-While we've striven to make CMakePP as foolproof as possible, the reality is
+While we've striven to make CMaize as foolproof as possible, the reality is
 bugs do occur and sometimes you build can get locked in a stale state.  Thus if
 a build fails we recommend you consider the following tips:
 
@@ -65,5 +65,5 @@ a build fails we recommend you consider the following tips:
 If your problem still persists check out our page
 :ref:`FAQs-and-Common-Build-Problems` to see if this a common problem.
 Finally, if you still can not resolve the problem consider opening an issue on
-CMakePP's GitHub repo (please look to see if an issue already exists before
+CMaize's GitHub repo (please look to see if an issue already exists before
 opening a new one).

--- a/docs/src/building/standard_cmake.rst
+++ b/docs/src/building/standard_cmake.rst
@@ -10,7 +10,7 @@ these variables when relevant and under no circumstance should a project
 override any of these variables (in rare circumstances appending to them may be
 needed, but you should never override them). The variables in this chapter are
 defined by CMake itself and therefore should be honored by all projects using
-CMake regardless of whether or not they used CMakePP. Note that the inopportune
+CMake regardless of whether or not they used CMaize. Note that the inopportune
 word there is **should**; you'll find a plethora of counterexamples (said
 counterexamples are bugs and should be reported).
 
@@ -57,7 +57,7 @@ as part of the standard and ``find_package`` automatically considers such
 variables as hints, regardless of whether the module recognizes the variable or
 not. CMake only strictly honors ``XXX_ROOT`` where ``XXX`` matches the case of
 the dependency's name; however, since determining the case can be annoying,
-CMakePP additionally will honor the all uppercase and all lowercase variants.
+CMaize additionally will honor the all uppercase and all lowercase variants.
 
 CMAKE_MODULE_PATH
 -----------------

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -11,7 +11,7 @@ import os
 
 # -- Project information -----------------------------------------------------
 
-project = u'CMakePP'
+project = u'CMaize'
 copyright = u'2020, CMakePP Team'
 author = u'CMakePP Team'
 #src_dir = u'utilities'

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,12 +1,11 @@
-###################################################
-Welcome to CMakePackagingProject's Documentation!!!
-###################################################
+####################################
+Welcome to CMaize's Documentation!!!
+####################################
 
-CMakePackagingProject is the top-level project of the CMakePP organization. It
-is this project which package maintainers should use to write their projects'
-build systems. Consequently, the CMakePackagingProject's documentation is the
-documentation to consult for generic help when it comes to building a project
-that uses CMakePP.
+CMaize is the top-level project of the CMakePP organization. It is this project
+which package maintainers should use to write their projects' build systems.
+Consequently, CMaize's documentation is the documentation to consult for
+generic help when it comes to building a project that uses CMaize.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/src/overview.rst
+++ b/docs/src/overview.rst
@@ -1,13 +1,13 @@
-*****************************
-CMakePP Build System Overview
-*****************************
+****************************
+CMaize Build System Overview
+****************************
 
-With CMakePP the build system for a C++ library can be as easy as:
+With CMaize the build system for a C++ library can be as easy as:
 
 .. code-block:: cmake
 
    cmake_minimum_required(VERSION 3.14)
-   project(your_first_cmakepp_project VERSION 1.0.0)
+   project(your_first_cmaize_project VERSION 1.0.0)
    include(cpp/cpp)
 
    cpp_add_library(
@@ -19,14 +19,14 @@ With CMakePP the build system for a C++ library can be as easy as:
 The above snippet will automatically find your library's header and source
 files, create and configure a CMake build target for your library, generate the
 packaging files for your library, and configure an install target. However, the
-real power of CMakePP is that it makes it easy to integrate dependencies into
+real power of CMaize is that it makes it easy to integrate dependencies into
 your project's build system. For example, if the library from the previous
 example depends on a dependency `name_of_dependency`:
 
 .. code-block:: cmake
 
    cmake_minimum_required(VERSION 3.14)
-   project(your_first_cmakepp_project VERSION 1.0.0)
+   project(your_first_cmaize_project VERSION 1.0.0)
    include(cpp/cpp)
 
    cpp_find_or_build_dependency(
@@ -44,5 +44,5 @@ example depends on a dependency `name_of_dependency`:
    )
 
 This relatively small snippet will properly look for the dependency using
-CMake's `find_package` command. If the dependency is not found, CMakePP will
+CMake's `find_package` command. If the dependency is not found, CMaize will
 then build it using CMake's `FetchContent` module.


### PR DESCRIPTION
Updates all references in the documentation to the "CMakePackagingProject" to use "CMaize". 

Note: any references to the CMakePP organization remain unchanged.