### PR TITLE
Add LANGUAGES NONE to project() to disable compiler checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14) # b/c of FetchContent_MakeAvailable
-project(CMaize VERSION 1.0.0)
+project(CMaize VERSION 1.0.0 LANGUAGES NONE)
 
 option(BUILD_TESTING "Should we build and run the unit tests?" OFF)
 


### PR DESCRIPTION
Disables unnecessary C and C++ compiler checking, speeds up first launch of CMaize and all projects depending on it substantially.