### PR TITLE
Module path fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ cpp_fetch_and_available(
         cmakepp_core
         GIT_REPOSITORY https://github.com/CMakePP/CMakePPCore
 )
+
+list(APPEND CMAKE_MODULE_PATH "${cmakepp_core_SOURCE_DIR}/cmake")
+
 set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
 
 if("${BUILD_TESTING}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,10 @@ cpp_fetch_and_available(
         GIT_REPOSITORY https://github.com/CMakePP/CMakePPCore
 )
 
-list(APPEND CMAKE_MODULE_PATH "${cmakepp_core_SOURCE_DIR}/cmake")
+
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 	set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE) #For projects including CMaize
 endif()
 set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14) # b/c of FetchContent_MakeAvailable
-project(CMaize VERSION 1.0.0)
+project(CMaize VERSION 1.0.0 LANGUAGES NONE)
 
 option(BUILD_TESTING "Should we build and run the unit tests?" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ cpp_fetch_and_available(
 
 list(APPEND CMAKE_MODULE_PATH "${cmakepp_core_SOURCE_DIR}/cmake")
 
+if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+	set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE) #For projects including CMaize
+endif()
 set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
 
 if("${BUILD_TESTING}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cpp_fetch_and_available(
 
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 	set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE) #For projects including CMaize
 endif()
 set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ set(build_testing_old "${BUILD_TESTING}")
 set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 cpp_fetch_and_available(
         cmakepp_core
-        GIT_REPOSITORY https://github.com/CMakePP/CMakePPCore
+        GIT_REPOSITORY https://github.com/AutonomicPerfectionist/CMakePPCore
+        GIT_TAG module_path_fix
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ cpp_fetch_and_available(
 
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 	set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE) #For projects including CMaize
 endif()
 set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,7 @@ set(build_testing_old "${BUILD_TESTING}")
 set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 cpp_fetch_and_available(
         cmakepp_core
-        GIT_REPOSITORY https://github.com/AutonomicPerfectionist/CMakePPCore
-        GIT_TAG module_path_fix
+        GIT_REPOSITORY https://github.com/CMakePP/CMakePPCore
 )
 
 


### PR DESCRIPTION
This pull request fixes an odd bug that has cropped up on certain systems recently. The bug causes a build failure because `CMAKE_MODULE_PATH` doesn't include the required directories, even though it worked before. I don't know what caused the bug to manifest but it affects my system (Ubuntu 21.10 w/ CMake 3.18.4) and Github Actions runners (Ubuntu 20.04, various CMake versions >= 3.18). This pull request shouldn't interfere with systems not encountering the bug as its only setting the new `CMAKE_MODULE_PATH` in parent scope if its not the top-level project.