### PR TITLE
Rename CMakePPCore to CMakePPLang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,14 @@ project(CMaize VERSION 1.0.0 LANGUAGES NONE)
 
 option(BUILD_TESTING "Should we build and run the unit tests?" OFF)
 
-# Include the fetch module and bring CMakePPCore into scope
+# Include the fetch module and bring CMakePPLang into scope
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(cpp/fetch/fetch_and_available)
 set(build_testing_old "${BUILD_TESTING}")
 set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 cpp_fetch_and_available(
-        cmakepp_core
-        GIT_REPOSITORY https://github.com/CMakePP/CMakePPCore
+        cmakepp_lang
+        GIT_REPOSITORY https://github.com/CMakePP/CMakePPLang
 )
 
 

--- a/cmake/cpp/dependency/dependency_class.cmake
+++ b/cmake/cpp/dependency/dependency_class.cmake
@@ -1,5 +1,5 @@
 include_guard()
-include(cmakepp_core/cmakepp_core)
+include(cmakepp_lang/cmakepp_lang)
 include(cpp/dependency/detail_/check_target)
 include(cpp/fetch/fetch_and_available)
 

--- a/cmake/cpp/targets/cxx_target.cmake
+++ b/cmake/cpp/targets/cxx_target.cmake
@@ -1,5 +1,5 @@
 include_guard()
-include(cmakepp_core/cmakepp_core)
+include(cmakepp_lang/cmakepp_lang)
 
 cpp_class(CXXTarget)
 

--- a/cmake/cpp/user_api/find_or_build_dependency.cmake
+++ b/cmake/cpp/user_api/find_or_build_dependency.cmake
@@ -1,5 +1,5 @@
 include_guard()
-include(cmakepp_core/cmakepp_core)
+include(cmakepp_lang/cmakepp_lang)
 include(cpp/dependency/dependency)
 
 function(cpp_find_or_build_dependency _fobd_name)


### PR DESCRIPTION
This PR renames CMakePPCore to CMakePPLang in CMaize as part of the renaming done in CMakePPCore PR #[35](https://github.com/CMakePP/CMakePPCore/pull/35), and should only be merged after 

- [x] CMakePPCore PR #[35](https://github.com/CMakePP/CMakePPCore/pull/35) is merged and 
- [x] the CMakePPCore repository is renamed to "CMakePPLang".