### PR TITLE
Ignore all build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ cmake-build-*
 .idea/
 
 # Build directories
-**/build
+build

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ cmake-build-*
 # CLion settings
 .idea/
 
-# Documentation build dir
-docs/build
+# Build directories
+**/build


### PR DESCRIPTION
This is a small update to the `.gitignore` to ignore all build directories, not just the documentation build.