### PR TITLE
Add Developer API Doc Generation to CI

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -34,8 +34,9 @@ jobs:
         run: |
           python3 -m venv virt_env
           source virt_env/bin/activate
+          pip3 install -r docs/requirements.txt
+          ./.github/workflows/scripts/build_api_docs.sh
           cd docs
-          pip3 install -r requirements.txt
           make html
           deactivate
 

--- a/.github/workflows/scripts/build_api_docs.sh
+++ b/.github/workflows/scripts/build_api_docs.sh
@@ -12,7 +12,8 @@ rm -rf docs/src/api/developer
 mkdir -p build
 
 # Build the API docs with CMinx
-cminx "cmake/cmaize" -o "build/api_docs/" -r -p cmaize
+cminx "cmake/cmaize" -o "build/api_docs/cmaize" -r -p cmaize
+cminx "cmake/cpp" -o "build/api_docs/cpp" -r -p cpp
 
 # Move the api docs to the documentation directory
 mv build/api_docs docs/src/api/developer

--- a/.github/workflows/scripts/build_api_docs.sh
+++ b/.github/workflows/scripts/build_api_docs.sh
@@ -16,7 +16,3 @@ cminx "cmake/cmaize" -o "build/api_docs/" -r -p cmaize
 
 # Move the api docs to the documentation directory
 mv build/api_docs docs/src/api/developer
-
-# Build the Sphinx docs
-cd docs
-make html

--- a/.github/workflows/scripts/build_docs.sh
+++ b/.github/workflows/scripts/build_docs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+
+# Start with a clean slate
+rm -rf docs/build
+rm -rf build/api_docs
+rm -rf docs/src/api/developer
+
+# Create a build directory for the api docs to be generated in
+mkdir -p build
+
+# Build the API docs with CMinx
+cminx "cmake/cmaize" -o "build/api_docs/" -r -p cmaize
+
+# Move the api docs to the documentation directory
+mv build/api_docs docs/src/api/developer
+
+# Build the Sphinx docs
+cd docs
+make html

--- a/docs/src/api/index.rst
+++ b/docs/src/api/index.rst
@@ -3,3 +3,8 @@ API
 ###
 
 This part provides the user API documentation for CMaize.
+
+.. toctree::
+   :maxdepth: 1
+   
+   Developer API <developer/index>

--- a/docs/src/api/index.rst
+++ b/docs/src/api/index.rst
@@ -7,6 +7,5 @@ This part provides the user API documentation for CMaize.
 .. toctree::
    :maxdepth: 1
    
-   Developer API <developer/index>
    Current Developer API <developer/cpp/index>
    Refactored Developer API (in progress) <developer/cmaize/index>

--- a/docs/src/api/index.rst
+++ b/docs/src/api/index.rst
@@ -8,3 +8,5 @@ This part provides the user API documentation for CMaize.
    :maxdepth: 1
    
    Developer API <developer/index>
+   Current Developer API <developer/cpp/index>
+   Refactored Developer API (in progress) <developer/cmaize/index>


### PR DESCRIPTION
This PR adds automated generation of developer API documentation to the CI. Although it is not explicitly mentioned in #61, I count it as part of fulfilling that issue in building and deploying the documentation. It includes two new documentation sections: "Current Developer API" for the code currently being used that lives under `cmake/cpp`, and "Refactored Developer API" for the in-progress refactor occurring in `cmake/cmaize`.

The commands to build the API documentation are contained within a script as `.github/workflows/scripts/build_api_docs.sh`.