### PR TITLE
Add manual trigger for workflows

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -17,6 +17,9 @@ on:
   push:
     branches:
       - master
+  
+  # Allows manual triggering with the "Run workflow" button
+  workflow_dispatch:
 
 jobs:
   Build-Documentation:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+  # Allows manual triggering with the "Run workflow" button
+  workflow_dispatch:
+
 jobs:
   linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allow the workflows to be triggered manually through a "Run workflow" button in the "Actions" tab. This is done by adding the `workflow_dispatch` event to the workflow triggers.

It just seems easier to have this in workflows in case they do not run on the merge of a PR, which sometimes happens.