### PR TITLE
Downgrade Python to 3.9 to fix workflow error

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Build Documentation
         run: |


### PR DESCRIPTION
Python 3.10 was throwing an error when trying to run `sphinx-build`. Downgrading Python to 3.9 fixes the issue.