### PR TITLE
Installed target class

### DIFF
--- a/cmake/cmaize/targets/installed_target.cmake
+++ b/cmake/cmaize/targets/installed_target.cmake
@@ -18,8 +18,8 @@ cpp_class(InstalledTarget)
     #
     # :param self: InstalledTarget object
     # :type self: InstalledTarget
-    # :param root_path: The top of the install location for the resource.
-    # :type root_path: path
+    # :param root: The top of the install location for the resource.
+    # :type root: path
     #
     # :returns: ``self`` will be set to the new instance of ``InstalledTarget``
     # :rtype: InstalledTarget

--- a/cmake/cmaize/targets/installed_target.cmake
+++ b/cmake/cmaize/targets/installed_target.cmake
@@ -1,10 +1,11 @@
 include_guard()
 include(cmakepp_lang/cmakepp_lang)
+include(cmaize/targets/target)
 
 #[[[
 # Wraps a target that is already installed on the system.
 #]]
-cpp_class(InstalledTarget)
+cpp_class(InstalledTarget Target)
 
     #[[[
     # :type: path

--- a/cmake/cmaize/targets/installed_target.cmake
+++ b/cmake/cmaize/targets/installed_target.cmake
@@ -19,16 +19,25 @@ cpp_class(InstalledTarget Target)
     #
     # :param self: InstalledTarget object
     # :type self: InstalledTarget
-    # :param root: The top of the install location for the resource.
+    # :param root: The top of the install location for the resource. Must
+    #              already exist.
     # :type root: path
     #
     # :returns: ``self`` will be set to the new instance of ``InstalledTarget``
     # :rtype: InstalledTarget
+    #
+    # :raises DirectoryNotFound: Root directory was not found.
     #]]
     cpp_constructor(CTOR InstalledTarget path)
     function("${CTOR}" self root)
 
-        # Maybe check if the root path exists here?
+        # Check if the root path exists
+        cpp_directory_exists(exists "${root}")
+        if(NOT exists)
+            set(msg "InstalledTarget root directory not found. ")
+            string(APPEND msg "Root given: ${root}")
+            cpp_raise(DirectoryNotFound "${msg}")
+        endif() 
 
         InstalledTarget(SET "${self}" root_path "${root}")
 

--- a/cmake/cmaize/targets/installed_target.cmake
+++ b/cmake/cmaize/targets/installed_target.cmake
@@ -1,0 +1,36 @@
+include_guard()
+include(cmakepp_lang/cmakepp_lang)
+
+#[[[
+# Wraps a target that is already installed on the system.
+#]]
+cpp_class(InstalledTarget)
+
+    #[[[
+    # :type: path
+    #
+    # The root directory of the installation.
+    #]]
+    cpp_attr(InstalledTarget root_path)
+
+    #[[[
+    # Instantiate a target for a resource that is already installed.
+    #
+    # :param self: InstalledTarget object
+    # :type self: InstalledTarget
+    # :param root_path: The top of the install location for the resource.
+    # :type root_path: path
+    #
+    # :returns: ``self`` will be set to the new instance of ``InstalledTarget``
+    # :rtype: InstalledTarget
+    #]]
+    cpp_constructor(CTOR InstalledTarget path)
+    function("${CTOR}" self root)
+
+        # Maybe check if the root path exists here?
+
+        InstalledTarget(SET "${self}" root_path "${root}")
+
+    endfunction()
+
+cpp_end_class()

--- a/docs/src/developer/design_notes/classes/index.rst
+++ b/docs/src/developer/design_notes/classes/index.rst
@@ -7,6 +7,7 @@ This chapter describes the design of different classes that make up CMaize.
 .. toctree::
    :maxdepth: 1
 
+   installed_target
    project_specification
    target
    toolchain

--- a/docs/src/developer/design_notes/classes/installed_target.rst
+++ b/docs/src/developer/design_notes/classes/installed_target.rst
@@ -1,0 +1,8 @@
+*********************
+InstalledTarget Class
+*********************
+
+This class encompasses pre-built and pre-installed targets on the system.
+Since they are already installed, CMaize does not need to build them, so 
+the ``InstalledTarget`` class is essentially just a wrapper for the root
+directory of the installation.

--- a/docs/src/developer/design_notes/classes/installed_target.rst
+++ b/docs/src/developer/design_notes/classes/installed_target.rst
@@ -6,3 +6,8 @@ This class encompasses pre-built and pre-installed targets on the system.
 Since they are already installed, CMaize does not need to build them, so 
 the ``InstalledTarget`` class is essentially just a wrapper for the root
 directory of the installation.
+
+.. note::
+
+   The root directory for the installation must exist at the time of
+   instantiation.

--- a/tests/cmaize/targets/test_installed_target.cmake
+++ b/tests/cmaize/targets/test_installed_target.cmake
@@ -1,0 +1,36 @@
+include(cmake_test/cmake_test)
+
+#[[[
+# Test the ``InstalledTarget`` class.
+#]]
+ct_add_test(NAME "test_tgt")
+function("${test_tgt}")
+    include(cmaize/targets/installed_target)
+
+    #[[[
+    # Test ``InstalledTarget(CTOR`` method.
+    #]]
+    ct_add_section(NAME "test_ctor")
+    function("${test_ctor}")
+
+        ct_add_section(NAME "test_dir_exists")
+        function("${test_dir_exists}")
+
+            InstalledTarget(CTOR tgt_obj "${CMAKE_CURRENT_SOURCE_DIR}")
+
+            InstalledTarget(GET "${tgt_obj}" result root_path)
+
+            ct_assert_equal(result "${CMAKE_CURRENT_SOURCE_DIR}")
+        
+        endfunction()
+
+        ct_add_section(NAME "test_dir_nonexistant" EXPECTFAIL)
+        function("${test_dir_nonexistant}")
+
+            InstalledTarget(CTOR tgt_obj "${CMAKE_CURRENT_SOURCE_DIR}/nonexistant")
+        
+        endfunction()
+
+    endfunction()
+
+endfunction()


### PR DESCRIPTION
Closes #69. Creates a class for targets that are already installed on the system.

- [x] Write the class
- [x] Test the class
- [x] Write design notes
- [x] Verify docs are complete and build