### PR TITLE
Create build target class

### DIFF
--- a/cmake/cmaize/targets/build_target.cmake
+++ b/cmake/cmaize/targets/build_target.cmake
@@ -8,14 +8,14 @@ include(cmaize/targets/target)
 cpp_class(BuildTarget Target)
 
     #[[[
-    # :type: list of path
+    # :type: List[path]
     #
     # Paths needed to compile or import.
     #]]
     cpp_attr(BuildTarget include_dirs)
 
     #[[[
-    # :type: list of path
+    # :type: List[path]
     #
     # Files needed to compile or import.
     #]]
@@ -29,14 +29,14 @@ cpp_class(BuildTarget Target)
     cpp_attr(BuildTarget project_specification)
 
     #[[[
-    # :type: list of BuildTarget
+    # :type: List[BuildTarget]
     #
     # Dependencies that need to be built.
     #]]
     cpp_attr(BuildTarget project_dependencies)
 
     #[[[
-    # :type: list of InstalledTarget
+    # :type: List[InstalledTarget]
     #
     # Dependencies that are already installed.
     #]]

--- a/cmake/cmaize/targets/build_target.cmake
+++ b/cmake/cmaize/targets/build_target.cmake
@@ -1,0 +1,73 @@
+include_guard()
+include(cmakepp_lang/cmakepp_lang)
+include(cmaize/targets/target)
+
+#[[[
+# Wraps a target which must be built as part of the build system.
+#]]
+cpp_class(BuildTarget Target)
+
+    #[[[
+    # :type: list of path
+    #
+    # Paths needed to compile or import.
+    #]]
+    cpp_attr(BuildTarget include_dirs)
+
+    #[[[
+    # :type: list of path
+    #
+    # Files needed to compile or import.
+    #]]
+    cpp_attr(BuildTarget include_files)
+
+    #[[[
+    # :type: ProjectSpecification
+    #
+    # The project specification for the current project.
+    #]]
+    cpp_attr(BuildTarget project_specification)
+
+    #[[[
+    # :type: list of BuildTarget
+    #
+    # Dependencies that need to be built.
+    #]]
+    cpp_attr(BuildTarget project_dependencies)
+
+    #[[[
+    # :type: list of InstalledTarget
+    #
+    # Dependencies that are already installed.
+    #]]
+    cpp_attr(BuildTarget system_dependencies)
+
+    #[[[
+    # Virtual member function for building the target.
+    # 
+    # :param self: BuildTarget object
+    # :type self: BuildTarget
+    #]]
+    cpp_member(make_target BuildTarget)
+    cpp_virtual_member(make_target)
+
+    #[[[
+    # Virtual member function to wrap calls to add_library, add_executable,
+    # add_custom_target, etc.
+    # 
+    # :param self: BuildTarget object
+    # :type self: BuildTarget
+    #]]
+    cpp_member(_create_target BuildTarget)
+    cpp_virtual_member(_create_target)
+
+    #[[[
+    # Virtual member function to set the include directories for the target.
+    # 
+    # :param self: BuildTarget object
+    # :type self: BuildTarget
+    #]]
+    cpp_member(_set_include_directories BuildTarget)
+    cpp_virtual_member(_set_include_directories)
+
+cpp_end_class()

--- a/cmake/cmaize/targets/targets.cmake
+++ b/cmake/cmaize/targets/targets.cmake
@@ -1,3 +1,5 @@
 include_guard()
 
+include(cmaize/targets/build_target)
+include(cmaize/targets/installed_target)
 include(cmaize/targets/target)

--- a/docs/src/developer/design_notes/classes/build_target.rst
+++ b/docs/src/developer/design_notes/classes/build_target.rst
@@ -2,7 +2,8 @@
 BuildTarget Class
 *****************
 
-This class serves as an abstract base class for language-specific target
+This class represents a target which must be built as part of the build
+system. It serves as an abstract base class for language-specific target
 classes of supported languages that CMaize can build.
 
 ``BuildTarget`` includes the basic information needed to build a target,

--- a/docs/src/developer/design_notes/classes/build_target.rst
+++ b/docs/src/developer/design_notes/classes/build_target.rst
@@ -1,0 +1,12 @@
+*****************
+BuildTarget Class
+*****************
+
+This class serves as an abstract base class for language-specific target
+classes of supported languages that CMaize can build.
+
+``BuildTarget`` includes the basic information needed to build a target,
+including the paths and files needed to compile or import, project
+specifications, and lists of dependencies that need to be built, along with
+those that are already installed on the system. Additionally, it includes
+general build functions that need to be overridden in children.

--- a/tests/cmaize/targets/test_build_target.cmake
+++ b/tests/cmaize/targets/test_build_target.cmake
@@ -1,0 +1,61 @@
+include(cmake_test/cmake_test)
+
+#[[[
+# Test the ``BuildTarget`` class.
+#]]
+ct_add_test(NAME "test_build_target")
+function("${test_build_target}")
+    include(cmaize/targets/build_target)
+
+    #[[[
+    # Test ``BuildTarget(make_target`` method.
+    #]]
+    ct_add_section(NAME "test_make_target")
+    function("${test_make_target}")
+
+        ct_add_section(NAME "virtual_throw" EXPECTFAIL)
+        function("${virtual_throw}")
+            set(tgt_name "test_build_target_make_target_virtual_throw")
+
+            BuildTarget(CTOR tgt_obj "${tgt_name}")
+
+            BuildTarget(make_target "${tgt_obj}")
+        endfunction()
+
+    endfunction()
+
+    #[[[
+    # Test ``BuildTarget(_create_target`` method.
+    #]]
+    ct_add_section(NAME "test__create_target")
+    function("${test__create_target}")
+
+        ct_add_section(NAME "virtual_throw" EXPECTFAIL)
+        function("${virtual_throw}")
+            set(tgt_name "test_build_target__create_target_virtual_throw")
+
+            BuildTarget(CTOR tgt_obj "${tgt_name}")
+
+            BuildTarget(_create_target "${tgt_obj}")
+        endfunction()
+
+    endfunction()
+
+    #[[[
+    # Test ``BuildTarget(_set_include_directories`` method.
+    #]]
+    ct_add_section(NAME "test__set_include_directories")
+    function("${test__set_include_directories}")
+
+        ct_add_section(NAME "virtual_throw" EXPECTFAIL)
+        function("${virtual_throw}")
+            set(tgt_name "test_build_target__set_include_directories_virtual_throw")
+
+            BuildTarget(CTOR tgt_obj "${tgt_name}")
+
+            BuildTarget(_set_include_directories "${tgt_obj}")
+        endfunction()
+
+    endfunction()
+
+endfunction()

--- a/tests/cmaize/targets/test_installed_target.cmake
+++ b/tests/cmaize/targets/test_installed_target.cmake
@@ -21,7 +21,7 @@ function("${test_tgt}")
             InstalledTarget(GET "${tgt_obj}" result root_path)
 
             ct_assert_equal(result "${CMAKE_CURRENT_SOURCE_DIR}")
-        
+
         endfunction()
 
         ct_add_section(NAME "test_dir_nonexistant" EXPECTFAIL)


### PR DESCRIPTION
Closes #68. Creates a `BuildTarget` class that will be the parent of all of the language targets that CMaize will support building.

#### Todo

- [x] Write the class
- [x] Write tests
- [x] Write design documentation