### PR TITLE
Fixed empty cxx standard if CMaize is included before a project is made

### DIFF
--- a/cmake/cmaize/targets/cxx_target.cmake
+++ b/cmake/cmaize/targets/cxx_target.cmake
@@ -76,6 +76,16 @@ cpp_class(CXXTarget BuildTarget)
             endif()
         endforeach()
 
+        # Default the CXX standard to CMAKE_CXX_STANDARD. This cannot be
+        # done by defaulting the attribute during the ``cpp_attr`` call
+        # since CMaize will be included before a project has been defined,
+        # making CMAKE_CXX_STANDARD, at the time of including, an empty
+        # string.
+        CXXTarget(GET "${self}" _mt_cxx_std cxx_standard)
+        if(NOT _mt_cxx_std)
+            CXXTarget(SET "${self}" cxx_standard "${CMAKE_CXX_STANDARD}")
+        endif()
+
         # Make all of the calls to create the CMake target and set its
         # properties
         CXXTarget(_create_target "${self}")

--- a/cmake/cmaize/targets/cxx_target.cmake
+++ b/cmake/cmaize/targets/cxx_target.cmake
@@ -82,7 +82,7 @@ cpp_class(CXXTarget BuildTarget)
         # making CMAKE_CXX_STANDARD, at the time of including, an empty
         # string.
         CXXTarget(GET "${self}" _mt_cxx_std cxx_standard)
-        if(NOT _mt_cxx_std)
+        if("${_mt_cxx_std}" STREQUAL "")
             CXXTarget(SET "${self}" cxx_standard "${CMAKE_CXX_STANDARD}")
         endif()
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
When CMaize is included before a `project()` command is run in `CMakeLists.txt`, the `cxx_standard` attribute of `CXXTarget` defaults to a blank value. This is because it defaults to the value of the `CMAKE_CXX_STANDARD` variable, which is blank until at least the first `project()` command is run.

I suspect this is caused by a bug in CMakePPLang which assigns default values to class attributes at CMaize include time rather than at object instantiation time. I assumed it was too deep-seated to be fixed easily, so I opted to work around it for now, but I will also make a minimum reproducible example and submit an issue for it in CMakePPLang.
