### PR TITLE
Split CMaizeProject target list

### DIFF
--- a/cmake/cmaize/project/project.cmake
+++ b/cmake/cmaize/project/project.cmake
@@ -152,16 +152,21 @@ cpp_class(CMaizeProject)
     #
     # :param self: CMaizeProject object.
     # :type self: CMaizeProject
-    # :param _at_language: Language to be added.
-    # :type _at_language: desc
+    # :param _al_language: Language to be added.
+    # :type _al_language: desc
     #]]
     cpp_member(add_language CMaizeProject desc)
-    function("${add_language}" self _at_language)
+    function("${add_language}" self _al_language)
 
-        CMaizeProject(GET "${self}" _at_language_list languages)
-        list(APPEND _at_language_list "${_at_language}")
-        list(REMOVE_DUPLICATES _at_language_list)
-        CMaizeProject(SET "${self}" languages "${_at_language_list}")
+        CMaizeProject(GET "${self}" _al_language_list languages)
+
+        list(FIND _al_language_list "${_al_language}" _al_found)
+
+        # Add the language to the list if it doesn't exist
+        if("${_al_found}" STREQUAL "-1")
+            list(APPEND _al_language_list "${_al_language}")
+            CMaizeProject(SET "${self}" languages "${_al_language_list}")
+        endif()
 
     endfunction()
 

--- a/cmake/cmaize/project/project.cmake
+++ b/cmake/cmaize/project/project.cmake
@@ -8,15 +8,17 @@ include(cmaize/utilities/utilities)
 # The ``CMaizeProject`` provides a workspace to collect information about a
 # project, using that information to build and package the project.
 #
+# This object will **not** create a CMake project if one does not already
+# exist.
+#
 # **Usage:**
 # 
 # A ``CMaizeProject`` object will be automatically created for the current
 # when CMaize is included in a ``CMakeLists.txt`` file if a ``project()``
-# call has already been made. Otherwise, the ``cmaize_project()`` user
-# function will create one and store it in the global
-# ``CMAIZE_PROJECT_<project_name>`` variable.
+# call has already been made. This project should not be created manually
+# in most cases.
 #
-# To retrieve an existing project object created in these ways, call:
+# To retrieve an existing project object, call:
 # 
 # .. code-block:: cmake
 #
@@ -67,15 +69,14 @@ cpp_class(CMaizeProject)
     cpp_attr(CMaizeProject installed_targets)
 
     #[[[
-    # Creates a ``CMaizeProject`` object and underlying CMake project, if
-    # necessary.
-    #
-    # The underlying CMake project is only created if the given project name
-    # does not match the CMake project name in ``PROJECT_NAME``.
+    # Creates a ``CMaizeProject`` object. A CMake project of the same name
+    # must already be created through a ``project()`` call and must be
+    # the active project.
     #
     # :param self: The constructed object.
     # :type self: CMaizeProject
-    # :param _ctor_name: Name of the project.
+    # :param _ctor_name: Name of the project. Must match the active project
+    #                    named in ``PROJECT_NAME``.
     # :type _ctor_name: desc
     #
     # :Keyword Arguments:
@@ -101,6 +102,9 @@ cpp_class(CMaizeProject)
     #      Languages supported by the project. These languages are passed to
     #      the LANGUAGES keyword of the CMake ``project()`` call if the project
     #      does not exist yet.
+    #
+    # :raises ProjectNotFound: The active CMake project does not match the
+    #                          given project name.
     #
     # :returns: ``self`` will be set to the newly constructed
     #           ``CMaizeProject`` object.
@@ -168,6 +172,11 @@ cpp_class(CMaizeProject)
     # :type self: CMaizeProject
     # :param _at_target: Target object to be added.
     # :type _at_target: Target
+    #
+    # :Keyword Arguments:
+    #    * **INSTALLED** (*bool*) --
+    #      Flag to indicate that the target being added is already installed
+    #      on the system.
     #]]
     cpp_member(add_target CMaizeProject Target args)
     function("${add_target}" self _at_target)

--- a/cmake/cmaize/project/project.cmake
+++ b/cmake/cmaize/project/project.cmake
@@ -1,6 +1,6 @@
 include_guard()
 include(cmakepp_lang/cmakepp_lang)
-include(cmaize/targets/targets)
+include(cmaize/targets/target)
 include(cmaize/project/project_specification)
 include(cmaize/utilities/utilities)
 

--- a/cmake/cmaize/project/project.cmake
+++ b/cmake/cmaize/project/project.cmake
@@ -1,6 +1,6 @@
 include_guard()
 include(cmakepp_lang/cmakepp_lang)
-include(cmaize/targets/target)
+include(cmaize/targets/targets)
 include(cmaize/project/project_specification)
 include(cmaize/utilities/utilities)
 

--- a/tests/cmaize/project/test_project.cmake
+++ b/tests/cmaize/project/test_project.cmake
@@ -95,6 +95,7 @@ function("${test_project}")
     ct_add_section(NAME "test_add_target")
     function("${test_add_target}")
         include(cmaize/targets/build_target)
+        include(cmaize/targets/installed_target)
 
         ct_add_section(NAME "build_target")
         function("${build_target}")

--- a/tests/cmaize/project/test_project.cmake
+++ b/tests/cmaize/project/test_project.cmake
@@ -96,10 +96,10 @@ function("${test_project}")
     function("${test_add_target}")
         include(cmaize/targets/build_target)
 
-        ct_add_section(NAME "single_target")
-        function("${single_target}")
+        ct_add_section(NAME "build_target")
+        function("${build_target}")
 
-            set(proj_name "test_project_test_add_target_single_target")
+            set(proj_name "test_project_test_add_target_build_target")
             set(tgt_name "${proj_name}_tgt")
 
             project("${proj_name}")
@@ -113,11 +113,40 @@ function("${test_project}")
             # Add a target
             CMaizeProject(add_target "${proj_obj}" "${tgt_obj}")
 
-            CMaizeProject(GET "${proj_obj}" tgt_list targets)
+            CMaizeProject(GET "${proj_obj}" tgt_list build_targets)
 
             # Make sure there is an element in the targets list
             list(LENGTH tgt_list tgt_list_len)
             ct_assert_equal(tgt_list_len 1)
+
+        endfunction()
+
+        ct_add_section(NAME "installed_target")
+        function("${installed_target}")
+
+            set(proj_name "test_project_test_add_target_installed_target")
+            set(tgt_name "${proj_name}_tgt")
+
+            project("${proj_name}")
+
+            CMaizeProject(CTOR proj_obj "${proj_name}")
+
+            InstalledTarget(CTOR tgt_obj "${tgt_name}")
+
+            CMaizeProject(GET "${proj_obj}" tmp_name name)        
+
+            # Add a target
+            CMaizeProject(add_target "${proj_obj}" "${tgt_obj}" INSTALLED)
+
+            CMaizeProject(GET "${proj_obj}" build_tgt_list build_targets)
+            CMaizeProject(GET "${proj_obj}" installed_tgt_list installed_targets)
+
+            # Make sure there is an element in the targets list
+            list(LENGTH build_tgt_list build_tgt_list_len)
+            ct_assert_equal(build_tgt_list_len 0)
+
+            list(LENGTH installed_tgt_list installed_tgt_list_len)
+            ct_assert_equal(installed_tgt_list_len 1)
 
         endfunction()
 
@@ -131,19 +160,25 @@ function("${test_project}")
 
             CMaizeProject(CTOR proj_obj "${proj_name}")
 
-            BuildTarget(CTOR tgt_obj "${tgt_name}")
+            BuildTarget(CTOR build_tgt_obj "${tgt_name}")
+            InstalledTarget(CTOR installed_tgt_obj "${tgt_name}")
 
             CMaizeProject(GET "${proj_obj}" tmp_name name)        
 
-            # Duplicate target should not be successfully added
-            CMaizeProject(add_target "${proj_obj}" "${tgt_obj}")
-            CMaizeProject(add_target "${proj_obj}" "${tgt_obj}")
+            # Duplicate targets should not be successfully added
+            CMaizeProject(add_target "${proj_obj}" "${build_tgt_obj}")
+            CMaizeProject(add_target "${proj_obj}" "${build_tgt_obj}")
+            CMaizeProject(add_target "${proj_obj}" "${installed_tgt_obj}" INSTALLED)
 
-            CMaizeProject(GET "${proj_obj}" tgt_list targets)
+            CMaizeProject(GET "${proj_obj}" build_tgt_list build_targets)
+            CMaizeProject(GET "${proj_obj}" installed_tgt_list installed_targets)
 
             # Make sure there is an element in the targets list
-            list(LENGTH tgt_list tgt_list_len)
-            ct_assert_equal(tgt_list_len 1)
+            list(LENGTH build_tgt_list build_tgt_list_len)
+            ct_assert_equal(build_tgt_list_len 1)
+
+            list(LENGTH installed_tgt_list installed_tgt_list_len)
+            ct_assert_equal(installed_tgt_list_len 0)
 
         endfunction()
 
@@ -170,9 +205,10 @@ function("${test_project}")
             # Duplicate target should not be successfully added
             CMaizeProject(add_target "${proj_obj}" "${tgt_obj_1}")
 
-            CMaizeProject(GET "${proj_obj}" tgt_list targets)
+            CMaizeProject(GET "${proj_obj}" tgt_list build_targets)
 
-            # Make sure there is an element in the targets list
+            # Make sure there are the corrent number of elements in
+            # the targets list
             list(LENGTH tgt_list tgt_list_len)
             ct_assert_equal(tgt_list_len 3)
 
@@ -182,6 +218,31 @@ function("${test_project}")
 
     ct_add_section(NAME "test_add_language")
     function("${test_add_language}")
+
+        ct_add_section(NAME "duplicate_languages")
+        function("${duplicate_languages}")
+
+            set(proj_name "test_project_test_add_language_duplicate_languages")
+            set(tgt_name "${proj_name}_tgt")
+
+            project("${proj_name}")
+
+            CMaizeProject(CTOR proj_obj "${proj_name}")  
+
+            # Add two distinct languages
+            CMaizeProject(add_language "${proj_obj}" C)
+            CMaizeProject(add_language "${proj_obj}" C)
+
+            CMaizeProject(GET "${proj_obj}" lang_list languages)
+
+            # Make sure there is an element in the languages list
+            list(LENGTH lang_list lang_list_len)
+            ct_assert_equal(lang_list_len 1)
+
+            # Test that the list contents are correct
+            ct_assert_equal(lang_list "C")
+
+        endfunction()
 
         ct_add_section(NAME "multiple_languages")
         function("${multiple_languages}")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Splits the CMaizeProject `targets` attribute into two lists, `build_targets` and `installed_targets`, to better track the type of targets associated with the project. There are also some minor bug fixes associated with adding targets and languages to the project.
