### PR TITLE
Disable setting public headers in CXX targets

### DIFF
--- a/cmake/cmaize/targets/cxx_target.cmake
+++ b/cmake/cmaize/targets/cxx_target.cmake
@@ -92,7 +92,7 @@ cpp_class(CXXTarget BuildTarget)
         CXXTarget(_set_compile_features "${self}")
         CXXTarget(_set_include_directories "${self}")
         CXXTarget(_set_link_libraries "${self}")
-        CXXTarget(_set_public_headers "${self}")
+        # CXXTarget(_set_public_headers "${self}")
         CXXTarget(_set_sources "${self}")
 
     endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR disables setting the `PUBLIC_HEADER` [property](https://cmake.org/cmake/help/latest/prop_tgt/PUBLIC_HEADER.html) on CXX targets. The `PUBLIC_HEADER` property is necessary for FRAMEWORK shared library targets for macOS and iOS, putting a list of header files into the `Headers` directory inside the framework folder, but for normal shared libraries, it results in a flat include directory instead of retaining any of the directory structure typically used when importing header files.

Since we are not currently attempting to support FRAMEWORK shared library targets for macOS and iOS and the flat directory of headers does not make sense for normal shared libraries, I am disabling setting `PUBLIC_HEADER` until we determine that we need it later. This also removes the warning about no `PUBLIC_HEADER DESTINATION` being set during installation.
