### PR TITLE
Fix version splitting function

### DIFF
--- a/cmake/cmaize/utilities/split_version.cmake
+++ b/cmake/cmaize/utilities/split_version.cmake
@@ -24,28 +24,28 @@ include_guard()
 # :returns: ``tweak`` will be set to the fourth component of ``version``.
 # :rtype: str
 #]]
-function(cmaize_split_version major minor patch tweak version)
+function(cmaize_split_version _sv_major _sv_minor _sv_patch _sv_tweak _sv_version)
 
     # Split the version into components
-    string(REPLACE "." ";" version_comps "${version}")
+    string(REPLACE "." ";" _sv_version_comps "${_sv_version}")
 
-    list(LENGTH version_comps comp_count)
+    list(LENGTH _sv_version_comps _sv_comp_count)
 
-    if (comp_count GREATER_EQUAL 1)
-        list(GET version_comps 0 tmp_major)
-        set(major "${tmp_major}" PARENT_SCOPE)
+    if (_sv_comp_count GREATER_EQUAL 1)
+        list(GET _sv_version_comps 0 _sv_tmp_major)
+        set("${_sv_major}" "${_sv_tmp_major}" PARENT_SCOPE)
     endif()
-    if (comp_count GREATER_EQUAL 2)
-        list(GET version_comps 1 tmp_minor)
-        set(minor "${tmp_minor}" PARENT_SCOPE)
+    if (_sv_comp_count GREATER_EQUAL 2)
+        list(GET _sv_version_comps 1 _sv_tmp_minor)
+        set("${_sv_minor}" "${_sv_tmp_minor}" PARENT_SCOPE)
     endif()
-    if (comp_count GREATER_EQUAL 3)
-        list(GET version_comps 2 tmp_patch)
-        set(patch "${tmp_patch}" PARENT_SCOPE)
+    if (_sv_comp_count GREATER_EQUAL 3)
+        list(GET _sv_version_comps 2 _sv_tmp_patch)
+        set("${_sv_patch}" "${_sv_tmp_patch}" PARENT_SCOPE)
     endif()
-    if (comp_count GREATER_EQUAL 4)
-        list(GET version_comps 3 tmp_tweak)
-        set(tweak "${tmp_tweak}" PARENT_SCOPE)
+    if (_sv_comp_count GREATER_EQUAL 4)
+        list(GET _sv_version_comps 3 _sv_tmp_tweak)
+        set("${_sv_tweak}" "${_sv_tmp_tweak}" PARENT_SCOPE)
     endif()
 
 endfunction()

--- a/cmake/cmaize/utilities/split_version.cmake
+++ b/cmake/cmaize/utilities/split_version.cmake
@@ -1,36 +1,43 @@
 include_guard()
 
 #[[[
-# Split the given version string into its components. Some return values
-# may be blank.
+# Split a given version string into its components.
 #
-# :param major: Returned first component of the version.
-# :type major: str
-# :param minor: Returned second component of the version.
-# :type minor: str
-# :param patch: Returned third component of the version.
-# :type patch: str
-# :param tweak: Returned fourth component of the version.
-# :type tweak: str
-# :param version: Version string to be separated into components.
-# :type version: str
+# This function assumes that semantic versioning (`https://semver.org`__)
+# is being used, as well as an additional, optional TWEAK component that
+# CMake natively supports. Some return values may be blank if there are not
+# four components to the version string.
 #
-# :returns: ``major`` will be set to the first component of ``version``.
-# :rtype: str
-# :returns: ``minor`` will be set to the second component of ``version``.
-# :rtype: str
-# :returns: ``patch`` will be set to the third component of ``version``.
-# :rtype: str
-# :returns: ``tweak`` will be set to the fourth component of ``version``.
-# :rtype: str
+# :param _sv_major: Returned first component of the version.
+# :type _sv_major: desc
+# :param _sv_minor: Returned second component of the version.
+# :type _sv_minor: desc
+# :param _sv_patch: Returned third component of the version.
+# :type _sv_patch: desc
+# :param _sv_tweak: Returned fourth component of the version.
+# :type _sv_tweak: desc
+# :param _sv_version: Version string to be separated into components.
+# :type _sv_version: desc
+#
+# :returns: The first component of the given version.
+# :rtype: desc
+# :returns: The second component of the given version.
+# :rtype: desc
+# :returns: The third component of the given version.
+# :rtype: desc
+# :returns: The fourth component of the given version.
+# :rtype: desc
 #]]
-function(cmaize_split_version _sv_major _sv_minor _sv_patch _sv_tweak _sv_version)
+function(cmaize_split_version
+    _sv_major _sv_minor _sv_patch _sv_tweak _sv_version
+)
 
     # Split the version into components
     string(REPLACE "." ";" _sv_version_comps "${_sv_version}")
 
     list(LENGTH _sv_version_comps _sv_comp_count)
 
+    # Extract each existing component
     if (_sv_comp_count GREATER_EQUAL 1)
         list(GET _sv_version_comps 0 _sv_tmp_major)
         set("${_sv_major}" "${_sv_tmp_major}" PARENT_SCOPE)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The `cmaize_split_version` function is not setting return variables correctly right now. It is setting new variables called `major`, `minor`, `patch`, and `tweak` in the parent scope, instead of setting the provided return variables to the return values.

This is fixed by surrounding `return_variable` in the `set(return_variable "return_value" PARENT_SCOPE)` with variable dereferencing, so it becomes `set("${return_variable}" "return_value" PARENT_SCOPE)`.

**TODOs**
- [x] Fix the issue described above.
- [x] Add name mangling to the local variables in the function to help avoid this type of issue (I wrote the function before I started doing it).
- [x] Update documentation to be more clear and reflect the parameter list changes.
