### PR TITLE
Add output messages to clarify find or build dependency

### DIFF
--- a/cmake/cpp/user_api/find_or_build_dependency.cmake
+++ b/cmake/cpp/user_api/find_or_build_dependency.cmake
@@ -14,10 +14,14 @@ function(cpp_find_or_build_dependency _fobd_name)
         cpp_set_global("__CPP_DEPENDENCY_${_fobd_name}__" "${_fobd_depend}")
     endif()
 
+    message(STATUS "Attempting to find installed _fobd_name")
+
     Dependency(FIND_DEPENDENCY "${_fobd_depend}" _fobd_found)
     if("${_fobd_found}")
         return()
     endif()
+    
+    message(STATUS "Attempting to fetch and build _fobd_name")
 
     Dependency(BUILD_DEPENDENCY "${_fobd_depend}")
 

--- a/cmake/cpp/user_api/find_or_build_dependency.cmake
+++ b/cmake/cpp/user_api/find_or_build_dependency.cmake
@@ -14,14 +14,14 @@ function(cpp_find_or_build_dependency _fobd_name)
         cpp_set_global("__CPP_DEPENDENCY_${_fobd_name}__" "${_fobd_depend}")
     endif()
 
-    message(STATUS "Attempting to find installed _fobd_name")
+    message(STATUS "Attempting to find installed ${_fobd_name}")
 
     Dependency(FIND_DEPENDENCY "${_fobd_depend}" _fobd_found)
     if("${_fobd_found}")
         return()
     endif()
     
-    message(STATUS "Attempting to fetch and build _fobd_name")
+    message(STATUS "Attempting to fetch and build ${_fobd_name}")
 
     Dependency(BUILD_DEPENDENCY "${_fobd_depend}")
 

--- a/cmake/cpp/user_api/find_or_build_dependency.cmake
+++ b/cmake/cpp/user_api/find_or_build_dependency.cmake
@@ -18,6 +18,7 @@ function(cpp_find_or_build_dependency _fobd_name)
 
     Dependency(FIND_DEPENDENCY "${_fobd_depend}" _fobd_found)
     if("${_fobd_found}")
+        message(STATUS "${_fobd_name} installation found")
         return()
     endif()
     

--- a/cmake/cpp/user_api/find_or_build_dependency.cmake
+++ b/cmake/cpp/user_api/find_or_build_dependency.cmake
@@ -26,6 +26,11 @@ function(cpp_find_or_build_dependency _fobd_name)
 
     Dependency(BUILD_DEPENDENCY "${_fobd_depend}")
 
+    # The command above will throw build errors from inside FetchContent
+    # if the fetch and build fails, so we can assume at this point that
+    # it completed successfully
+    message(STATUS "${_fobd_name} build complete")
+
     # Alias the build target as the find_target to unify the API
     Dependency(GET "${_fobd_depend}" _fobd_find_target "find_target")
     Dependency(GET "${_fobd_depend}" _fobd_build_target "build_target")
@@ -35,4 +40,5 @@ function(cpp_find_or_build_dependency _fobd_name)
         endif()
         add_library("${_fobd_find_target}" ALIAS "${_fobd_build_target}")
     endif()
+
 endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #92.

**Description**
This PR adds some additional output to the `cpp_find_or_build_dependency()` command to better clarify what action is being performed.
