### PR TITLE
Rename 'Target' -> 'CMaizeTarget'

### DIFF
--- a/cmake/cmaize/package_managers/cmake_package_manager.cmake
+++ b/cmake/cmaize/package_managers/cmake_package_manager.cmake
@@ -160,7 +160,7 @@ cpp_class(CMakePackageManager PackageManager)
         set(_ip_options NAMESPACE)
         cmake_parse_arguments(_ip "" "${_ip_options}" "" ${ARGN})
 
-        Target(target "${_ip_target}" _ip_tgt_name)
+        CMaizeTarget(target "${_ip_target}" _ip_tgt_name)
 
         if("${_ip_NAMESPACE}" STREQUAL "")
             set(_ip_NAMESPACE "${PROJECT_NAME}::")

--- a/cmake/cmaize/package_managers/package_manager.cmake
+++ b/cmake/cmaize/package_managers/package_manager.cmake
@@ -29,7 +29,7 @@ cpp_class(PackageManager)
     #[[[
     # Virtual member to install a package.
     #]]
-    cpp_member(install_package PackageManager Target)
+    cpp_member(install_package PackageManager CMaizeTarget)
     cpp_virtual_member(install_package)
 
 cpp_end_class()

--- a/cmake/cmaize/project/project.cmake
+++ b/cmake/cmaize/project/project.cmake
@@ -202,15 +202,15 @@ cpp_class(CMaizeProject)
     #
     # :param self: CMaizeProject object.
     # :type self: CMaizeProject
-    # :param _at_target: Target object to be added.
-    # :type _at_target: Target
+    # :param _at_target: CMaizeTarget object to be added.
+    # :type _at_target: CMaizeTarget
     #
     # :Keyword Arguments:
     #    * **INSTALLED** (*bool*) --
     #      Flag to indicate that the target being added is already installed
     #      on the system.
     #]]
-    cpp_member(add_target CMaizeProject Target args)
+    cpp_member(add_target CMaizeProject CMaizeTarget args)
     function("${add_target}" self _at_target)
 
         set(_at_flags INSTALLED)
@@ -222,7 +222,7 @@ cpp_class(CMaizeProject)
             set(_at_tgt_attr "installed_targets")
         endif()
 
-        # Check if a Target with the same name exists already
+        # Check if a CMaizeTarget with the same name exists already
         CMaizeProject(check_target "${self}" _at_found "${_at_target}")
 
         # Add the target to the list if it doesn't already exist
@@ -282,15 +282,15 @@ cpp_class(CMaizeProject)
     # :param _ct_found: Return variable for if the target was found.
     # :type _ct_found: bool*
     # :param _ct_tgt: Target to search for.
-    # :type _ct_tgt: Target
+    # :type _ct_tgt: CMaizeTarget
     #
     # :returns: Target found (TRUE) or not (FALSE).
     # :rtype: bool
     #]]
-    cpp_member(check_target CMaizeProject desc Target)
+    cpp_member(check_target CMaizeProject desc CMaizeTarget)
     function("${check_target}" self  _ct_found _ct_tgt)
 
-        Target(target "${_ct_tgt}" _ct_tgt_name)
+        CMaizeTarget(target "${_ct_tgt}" _ct_tgt_name)
 
         # Search each list of targets in the project
         foreach(_ct_tgt_list_i "build_targets" "installed_targets")
@@ -298,7 +298,7 @@ cpp_class(CMaizeProject)
 
             # Search the list for a target with a matching name
             foreach(_ct_tgt_i ${_ct_tgt_list})
-                Target(target "${_ct_tgt_i}" _ct_tgt_i_name)
+                CMaizeTarget(target "${_ct_tgt_i}" _ct_tgt_i_name)
                 
                 # Exit early if a target with the same name is found
                 if("${_ct_tgt_name}" STREQUAL "${_ct_tgt_i_name}")

--- a/cmake/cmaize/targets/build_target.cmake
+++ b/cmake/cmaize/targets/build_target.cmake
@@ -5,7 +5,7 @@ include(cmaize/targets/target)
 #[[[
 # Wraps a target which must be built as part of the build system.
 #]]
-cpp_class(BuildTarget Target)
+cpp_class(BuildTarget CMaizeTarget)
 
     #[[[
     # :type: List[path]
@@ -43,7 +43,7 @@ cpp_class(BuildTarget Target)
     # cpp_attr(BuildTarget system_dependencies)
 
     #[[[
-    # :type List[Target]
+    # :type List[CMaizeTarget]
     #
     # Targets that are dependencies.
     #]]

--- a/cmake/cmaize/targets/installed_target.cmake
+++ b/cmake/cmaize/targets/installed_target.cmake
@@ -5,7 +5,7 @@ include(cmaize/targets/target)
 #[[[
 # Wraps a target that is already installed on the system.
 #]]
-cpp_class(InstalledTarget Target)
+cpp_class(InstalledTarget CMaizeTarget)
 
     #[[[
     # :type: path

--- a/cmake/cmaize/targets/target.cmake
+++ b/cmake/cmaize/targets/target.cmake
@@ -4,60 +4,60 @@ include(cmakepp_lang/cmakepp_lang)
 #[[[
 # Base class for an entire hierarchy of build and install target classes.
 #]]
-cpp_class(Target)
+cpp_class(CMaizeTarget)
 
     #[[[
-    # Creates a ``Target`` object to manage a target of the given name.
+    # Creates a ``CMaizeTarget`` object to manage a target of the given name.
     # 
     # .. note::
     #    
     #    This does not create a corresponding CMake target,
     #    so any call that should interact with a target will fail if the
     #    target does not already exist. As a base class with no concrete
-    #    analog, ``Target`` really shouldn't be instantiated aside from
+    #    analog, ``CMaizeTarget`` really shouldn't be instantiated aside from
     #    testing purposes. Instead, create a child with a concrete target
     #    analog and instantiate that.
     #
-    # :param self: Target object constructed.
-    # :type self: Target
+    # :param self: CMaizeTarget object constructed.
+    # :type self: CMaizeTarget
     # :param tgt_name: Name of the target. This should not duplicate any other
     #                  target name already in scope.
     # :type tgt_name: str
-    # :returns: ``self`` will be set to the newly constructed ``Target``
+    # :returns: ``self`` will be set to the newly constructed ``CMaizeTarget``
     #           object.
-    # :rtype: Target
+    # :rtype: CMaizeTarget
     #]]
-    cpp_constructor(CTOR Target str)
+    cpp_constructor(CTOR CMaizeTarget str)
     function("${CTOR}" self tgt_name)
 
-        Target(SET "${self}" _name "${tgt_name}")
+        CMaizeTarget(SET "${self}" _name "${tgt_name}")
 
     endfunction()
 
     #[[[
-    # Creates a ``Target`` object based on an existing CMake target.
+    # Creates a ``CMaizeTarget`` object based on an existing CMake target.
     #
-    # :param self: Target object constructed.
-    # :type self: Target
+    # :param self: CMaizeTarget object constructed.
+    # :type self: CMaizeTarget
     # :param tgt_name: Name of the existing target.
     # :type tgt_name: str
     #
-    # :returns: ``self`` will be set to the newly constructed ``Target``
+    # :returns: ``self`` will be set to the newly constructed ``CMaizeTarget``
     #           object.
-    # :rtype: Target
+    # :rtype: CMaizeTarget
     #]]
-    cpp_constructor(CTOR Target target)
+    cpp_constructor(CTOR CMaizeTarget target)
     function("${CTOR}" self tgt_name)
 
-        Target(SET "${self}" _name "${tgt_name}")
+        CMaizeTarget(SET "${self}" _name "${tgt_name}")
 
     endfunction()
 
     #[[[
-    # Get the CMake target name that the ``Target`` class represents.
+    # Get the CMake target name that the ``CMaizeTarget`` class represents.
     # 
-    # :param self: Target object
-    # :type self: Target
+    # :param self: CMaizeTarget object
+    # :type self: CMaizeTarget
     # :param return_target: Name of the CMake target.
     # :type return_target: str*
     #
@@ -65,10 +65,10 @@ cpp_class(Target)
     #           represented by this class.
     # :rtype: str*
     #]]
-    cpp_member(target Target str)
+    cpp_member(target CMaizeTarget str)
     function("${target}" self return_target)
 
-        Target(GET "${self}" "${return_target}" _name)
+        CMaizeTarget(GET "${self}" "${return_target}" _name)
 
         cpp_return("${return_target}")
 
@@ -77,8 +77,8 @@ cpp_class(Target)
     #[[[
     # Check if the target has the requested property.
     # 
-    # :param self: Target object
-    # :type self: Target
+    # :param self: CMaizeTarget object
+    # :type self: CMaizeTarget
     # :param has_property: Return variable for if the target has the property.
     # :type has_property: bool*
     # :param property_name: Name of the property to check for.
@@ -88,10 +88,10 @@ cpp_class(Target)
     #           requested property (True) or not (False).
     # :rtype: bool*
     #]]
-    cpp_member(has_property Target desc str)
+    cpp_member(has_property CMaizeTarget desc str)
     function("${has_property}" self has_property property_name)
 
-        Target(target "${self}" my_name)
+        CMaizeTarget(target "${self}" my_name)
 
         # Call CMake's built-in `get_target_property()` method.
         get_target_property(property_value "${my_name}" "${property_name}")
@@ -113,10 +113,10 @@ cpp_class(Target)
     endfunction()
 
     #[[[
-    # Get the requested property for the ``Target``.
+    # Get the requested property for the ``CMaizeTarget``.
     # 
-    # :param self: Target object
-    # :type self: Target
+    # :param self: CMaizeTarget object
+    # :type self: CMaizeTarget
     # :param property_value: Return variable for the property value.
     # :type property_value: str*
     # :param property_name: Name of the property to check for.
@@ -127,15 +127,15 @@ cpp_class(Target)
     #
     # :raises PropertyNotFound: Property does not exist in the target.
     #]]
-    cpp_member(get_property Target str str)
+    cpp_member(get_property CMaizeTarget str str)
     function("${get_property}" self property_value property_name)
 
-        Target(has_property "${self}" prop_exists "${property_name}")
+        CMaizeTarget(has_property "${self}" prop_exists "${property_name}")
         if(NOT prop_exists)
             cpp_raise(PropertyNotFound "Property not found: ${property_name}")
         endif()
 
-        Target(target "${self}" my_name)
+        CMaizeTarget(target "${self}" my_name)
 
         # Call CMake's built-in `get_target_property()` method.
         get_target_property("${property_value}" "${my_name}" "${property_name}")
@@ -148,8 +148,8 @@ cpp_class(Target)
     # Sets a single property to the given value, creating the property if it
     # does not exist.
     #
-    # :param self: Target object
-    # :type self: Target
+    # :param self: CMaizeTarget object
+    # :type self: CMaizeTarget
     # :param _sp_property_name: Name of the property to set.
     # :type _sp_property_name: desc
     # :param args: Values of the property. This uses all additional
@@ -158,7 +158,7 @@ cpp_class(Target)
     #              TODO: Verify how to document this parameter properly
     # :type args: args
     #]]
-    cpp_member(set_property Target desc args)
+    cpp_member(set_property CMaizeTarget desc args)
     function("${set_property}" self _sp_property_name)
 
         # Package the property into a map
@@ -167,7 +167,7 @@ cpp_class(Target)
         # TODO: This may hang or throw if no property value is given (ARGN)
         cpp_map(SET "${_sp_prop_map}" "${_sp_property_name}" "${ARGN}")
 
-        Target(set_properties "${self}" "${_sp_prop_map}")
+        CMaizeTarget(set_properties "${self}" "${_sp_prop_map}")
 
     endfunction()
 
@@ -181,8 +181,8 @@ cpp_class(Target)
     #    using a ``cpp_map`` is close, so it was used. See the example usage
     #    below for a concise way of using this function.
     #
-    # :param self: Target object
-    # :type self: Target
+    # :param self: CMaizeTarget object
+    # :type self: CMaizeTarget
     # :param _sp_properties: Property names and values.
     # :type _sp_properties: cpp_map
     #
@@ -193,8 +193,8 @@ cpp_class(Target)
     #    # Create a target so the property functions have something to act on
     #    add_custom_target("example_target")
     # 
-    #    # Create a Target object
-    #    Target(CTOR my_tgt "example_target")
+    #    # Create a CMaizeTarget object
+    #    CMaizeTarget(CTOR my_tgt "example_target")
     #
     #    # Assign properties using the cpp_map constructor with the optional
     #    # key-value pairs in the CTOR call
@@ -207,12 +207,12 @@ cpp_class(Target)
     #    )
     #
     #    # Set the properties on the target with this function
-    #    Target(set_properties "${property_map}")
+    #    CMaizeTarget(set_properties "${property_map}")
     #]]
-    cpp_member(set_properties Target map)
+    cpp_member(set_properties CMaizeTarget map)
     function("${set_properties}" self _sp_properties)
 
-        Target(target "${self}" _sp_tgt_name)
+        CMaizeTarget(target "${self}" _sp_tgt_name)
 
         cpp_map(KEYS "${_sp_properties}" _sp_keys)
 
@@ -232,7 +232,7 @@ cpp_class(Target)
     #
     # Name of the current target.
     #]]
-    cpp_attr(Target _name)
+    cpp_attr(CMaizeTarget _name)
 
 cpp_end_class()
 

--- a/cmake/cmaize/user_api/add_package.cmake
+++ b/cmake/cmaize/user_api/add_package.cmake
@@ -59,7 +59,7 @@ function(cmaize_add_package_cmake _capc_tgt_name)
 
     # Search for the correct target to package
     foreach(tgt_i ${tgt_list})
-        Target(target "${tgt_i}" _capc_name)
+        CMaizeTarget(target "${tgt_i}" _capc_name)
         if("${_capc_name}" STREQUAL "${_capc_tgt_name}")
             PackageManager(install_package
                 "${_capc_pm_obj}"

--- a/tests/cmaize/project/test_project.cmake
+++ b/tests/cmaize/project/test_project.cmake
@@ -8,7 +8,7 @@ function("${test_project}")
     include(cmaize/project/project)
 
     #[[[
-    # Test ``Target(CTOR`` method.
+    # Test ``CMaizeTarget(CTOR`` method.
     #]]
     ct_add_section(NAME "test_ctor")
     function("${test_ctor}")

--- a/tests/cmaize/targets/test_target.cmake
+++ b/tests/cmaize/targets/test_target.cmake
@@ -1,14 +1,14 @@
 include(cmake_test/cmake_test)
 
 #[[[
-# Test the ``Target`` class.
+# Test the ``CMaizeTarget`` class.
 #]]
 ct_add_test(NAME "test_tgt")
 function("${test_tgt}")
     include(cmaize/targets/target)
 
     #[[[
-    # Test ``Target(CTOR`` method.
+    # Test ``CMaizeTarget(CTOR`` method.
     #]]
     ct_add_section(NAME "test_ctor")
     function("${test_ctor}")
@@ -17,9 +17,9 @@ function("${test_tgt}")
         function("${test_nonexistant_tgt}")
             set(tgt_name "test_tgt_ctor_nonexistant_tgt")
 
-            Target(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
 
-            Target(GET "${tgt_obj}" result _name)
+            CMaizeTarget(GET "${tgt_obj}" result _name)
 
             ct_assert_equal(result "${tgt_name}")
         endfunction()
@@ -39,10 +39,10 @@ function("${test_tgt}")
                 PROPERTY "${prop_name}" "${prop_value}"
             )
 
-            Target(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
 
             # Test that the name is correct
-            Target(GET "${tgt_obj}" result _name)
+            CMaizeTarget(GET "${tgt_obj}" result _name)
             ct_assert_equal(result "${tgt_name}")
 
             # Test that the property set beforehand still exists with
@@ -54,7 +54,7 @@ function("${test_tgt}")
     endfunction()
 
     #[[[
-    # Test ``Target(target`` method.
+    # Test ``CMaizeTarget(target`` method.
     #]]
     ct_add_section(NAME "test_get_target")
     function("${test_get_target}")
@@ -63,13 +63,13 @@ function("${test_tgt}")
         function("${nonexistant_tgt}")
             set(tgt_name "test_tgt_get_target_nonexistant_tgt")
 
-            Target(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
 
             # Explicitly set the _name variable to avoid testing assignment
             # bugs in the CTOR
-            Target(SET "${tgt_obj}" _name "${tgt_name}")
+            CMaizeTarget(SET "${tgt_obj}" _name "${tgt_name}")
 
-            Target(target "${tgt_obj}" result)
+            CMaizeTarget(target "${tgt_obj}" result)
 
             ct_assert_equal(result "${tgt_name}")
         endfunction()
@@ -79,13 +79,13 @@ function("${test_tgt}")
             set(tgt_name "test_tgt_get_target_existing_tgt")
             add_custom_target("${tgt_name}")
 
-            Target(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
 
             # Explicitly set the _name variable to avoid testing assignment
             # bugs in the CTOR
-            Target(SET "${tgt_obj}" _name "${tgt_name}")
+            CMaizeTarget(SET "${tgt_obj}" _name "${tgt_name}")
 
-            Target(target "${tgt_obj}" result)
+            CMaizeTarget(target "${tgt_obj}" result)
 
             ct_assert_equal(result "${tgt_name}")
         endfunction()
@@ -93,7 +93,7 @@ function("${test_tgt}")
     endfunction()
     
     #[[[
-    # Test ``Target(has_property`` method.
+    # Test ``CMaizeTarget(has_property`` method.
     #]]
     ct_add_section(NAME "test_has_property")
     function("${test_has_property}")
@@ -104,9 +104,9 @@ function("${test_tgt}")
             set(tgt_name "test_tgt_has_property_invalid_property")
             add_custom_target("${tgt_name}")
 
-            Target(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
 
-            Target(has_property "${tgt_obj}" result "invalid_property")
+            CMaizeTarget(has_property "${tgt_obj}" result "invalid_property")
 
             ct_assert_equal(result FALSE)
 
@@ -123,9 +123,9 @@ function("${test_tgt}")
                 PROPERTY "${prop_name}" "test_value"
             )
 
-            Target(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
             
-            Target(has_property "${tgt_obj}" result "${prop_name}")
+            CMaizeTarget(has_property "${tgt_obj}" result "${prop_name}")
 
             ct_assert_equal(result TRUE)
 
@@ -134,7 +134,7 @@ function("${test_tgt}")
     endfunction()
 
     #[[[
-    # Test ``Target(get_property`` method.
+    # Test ``CMaizeTarget(get_property`` method.
     #]]
     ct_add_section(NAME "test_get_property")
     function("${test_get_property}")
@@ -145,10 +145,10 @@ function("${test_tgt}")
             set(tgt_name "test_tgt_get_property_invalid_property")
             add_custom_target("${tgt_name}")
 
-            Target(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
 
             # Should raise a PropertyNotFound
-            Target(get_property "${tgt_obj}" result "invalid_property")
+            CMaizeTarget(get_property "${tgt_obj}" result "invalid_property")
 
         endfunction()
 
@@ -164,9 +164,9 @@ function("${test_tgt}")
                 PROPERTY "${prop_name}" "${prop_value}"
             )
 
-            Target(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
 
-            Target(get_property "${tgt_obj}" result "${prop_name}")
+            CMaizeTarget(get_property "${tgt_obj}" result "${prop_name}")
 
             ct_assert_equal(result "${prop_value}")
 
@@ -175,7 +175,7 @@ function("${test_tgt}")
     endfunction()
 
     #[[[
-    # Test ``Target(set_property`` method.
+    # Test ``CMaizeTarget(set_property`` method.
     #]]
     ct_add_section(NAME "test_set_property")
     function("${test_set_property}")
@@ -192,8 +192,8 @@ function("${test_tgt}")
             add_custom_target("${tgt_name}")
 
             # Set the property value on the target
-            Target(CTOR tgt_obj "${tgt_name}")
-            Target(set_property "${tgt_obj}" "${prop_name}" "${prop_value}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(set_property "${tgt_obj}" "${prop_name}" "${prop_value}")
 
             # Check the property value on the target
             get_target_property(result "${tgt_name}" "${prop_name}")
@@ -219,16 +219,16 @@ function("${test_tgt}")
                 PROPERTY "${prop_name}" "${prop_value}"
             )
 
-            # Set the property again in the Target object
-            Target(CTOR tgt_obj "${tgt_name}")
-            Target(set_property "${tgt_obj}" "${prop_name}" "${prop_value2}")
+            # Set the property again in the CMaizeTarget object
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(set_property "${tgt_obj}" "${prop_name}" "${prop_value2}")
 
             get_target_property(result "${tgt_name}" "${prop_name}")
             ct_assert_equal(result "${prop_value2}")
 
-            # This will overwrite the value that the Target object just
+            # This will overwrite the value that the CMaizeTarget object just
             # overwrote above
-            Target(set_property "${tgt_obj}" "${prop_name}" "${prop_value3}")
+            CMaizeTarget(set_property "${tgt_obj}" "${prop_name}" "${prop_value3}")
 
             get_target_property(result "${tgt_name}" "${prop_name}")
             ct_assert_equal(result "${prop_value3}")
@@ -238,7 +238,7 @@ function("${test_tgt}")
     endfunction()
 
     #[[[
-    # Test ``Target(set_properties`` method.
+    # Test ``CMaizeTarget(set_properties`` method.
     #]]
     ct_add_section(NAME "test_set_properties")
     function("${test_set_properties}")
@@ -258,8 +258,8 @@ function("${test_tgt}")
             add_custom_target("${tgt_name}")
 
             # Set the property value on the target
-            Target(CTOR tgt_obj "${tgt_name}")
-            Target(set_properties "${tgt_obj}" "${property_map}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(set_properties "${tgt_obj}" "${property_map}")
 
             # Check the property value on the target
             get_target_property(result_1 "${tgt_name}" "test_name_1")
@@ -290,8 +290,8 @@ function("${test_tgt}")
             )
 
             # Set the property value on the target
-            Target(CTOR tgt_obj "${tgt_name}")
-            Target(set_properties "${tgt_obj}" "${property_map}")
+            CMaizeTarget(CTOR tgt_obj "${tgt_name}")
+            CMaizeTarget(set_properties "${tgt_obj}" "${property_map}")
 
             # Check the property value on the target
             get_target_property(result_1 "${tgt_name}" "test_name_1")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR renames the `Target` object to `CMaizeTarget` so it does not conflict with the `target` built-in type of CMakePPLang. This is necessary after a recent change to CMakePPLang that checks for conflicts between built-in types and user-defined class names ([PR 62](https://github.com/CMakePP/CMakePPLang/pull/62)).