### PR TITLE
Fix reference to CMaize global variable

### DIFF
--- a/cmake/cmaize/user_api/add_executable.cmake
+++ b/cmake/cmaize/user_api/add_executable.cmake
@@ -141,7 +141,7 @@ function(cmaize_add_cxx_executable _cace_tgt_obj _cace_tgt_name)
     # defaulting to CMAIZE_CXX_INCLUDE_FILE_EXTENSIONS
     list(LENGTH _cace_INCLUDE_EXTS _cace_INCLUDE_EXTS_n)
     if(NOT "${_cace_INCLUDE_EXTS_n}" GREATER 0)
-        set(_cace_INCLUDE_EXTS "${CMAIZE_CXX_INCLUDE_FILE_EXTENSIONS}")
+        cpp_get_global(_cacl_INCLUDE_EXTS CMAIZE_CXX_INCLUDE_FILE_EXTENSIONS)
     endif()
 
     _cmaize_glob_files(_cace_source_files "${_cace_SOURCE_DIR}" "${_cace_SOURCE_EXTS}")

--- a/cmake/cmaize/user_api/add_library.cmake
+++ b/cmake/cmaize/user_api/add_library.cmake
@@ -137,7 +137,7 @@ function(cmaize_add_cxx_library _cacl_tgt_obj _cacl_tgt_name)
     # defaulting to CMAIZE_CXX_INCLUDE_FILE_EXTENSIONS
     list(LENGTH _cacl_INCLUDE_EXTS _cacl_INCLUDE_EXTS_n)
     if(NOT "${_cacl_INCLUDE_EXTS_n}" GREATER 0)
-        set(_cacl_INCLUDE_EXTS "${CMAIZE_CXX_INCLUDE_FILE_EXTENSIONS}")
+        cpp_get_global(_cacl_INCLUDE_EXTS CMAIZE_CXX_INCLUDE_FILE_EXTENSIONS)
     endif()
 
     _cmaize_glob_files(_cacl_source_files "${_cacl_SOURCE_DIR}" "${_cacl_SOURCE_EXTS}")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The CMaize global variable, `CMAIZE_CXX_INCLUDE_FILE_EXTENSIONS`, was not being referenced correctly in the `cmaize_add_library()` and `cmaize_add_executable()` functions, so we were not getting the actual value of the global variable.