### PR TITLE
Enable default SSH access to private GitHub repositories

### DIFF
--- a/cmake/cmaize/globals.cmake
+++ b/cmake/cmaize/globals.cmake
@@ -11,6 +11,17 @@ cpp_set_global(
 )
 
 #[[[
+# URL prefix for GitHub SSH access. Defaults to ``git@github.com``. 
+# This option allows for SSH aliases, e.g. ``git@github-alt-account``
+# where ``githut-alt-account` is a user-defined alias for GitHub
+# SSH access defined in a user's $HOME/.ssh/config.
+#]]
+cpp_set_global(
+    CMAIZE_GITHUB_SSH_PREFIX
+    "git@github.com"
+)
+
+#[[[
 # GitHub token used to access private repositories. It is defaulted to the
 # value of the old ``CPP_GITHUB_TOKEN`` for backwards compatability and
 # will be a blank string ("") if ``CPP_GITHUB_TOKEN`` does not exist.
@@ -18,6 +29,16 @@ cpp_set_global(
 cpp_set_global(
     CMAIZE_GITHUB_TOKEN
     "${CPP_GITHUB_TOKEN}"
+)
+
+#[[[
+# Use SSH access for private GitHub repositories toa void OAuth token
+# requirements. See ``CMAIZE_GITHUB_SSH_PREFIX`` for details pertaining
+# to chaging default GitHub SSH access prefixes.
+#]]
+cpp_set_global(
+    CMAIZE_GITHUB_USE_SSH
+    OFF
 )
 
 #[[[

--- a/cmake/cmaize/package_managers/cmake/dependency/github.cmake
+++ b/cmake/cmaize/package_managers/cmake/dependency/github.cmake
@@ -37,6 +37,10 @@ cpp_class(GitHubDependency Dependency)
         GitHubDependency(GET "${_bd_this}" _bd_name name)
         GitHubDependency(GET "${_bd_this}" _bd_cmake_args cmake_args)
 
+        if( _bd_private AND CMAIZE_GITHUB_USE_SSH )
+          string( REPLACE "github.com/" "${CMAIZE_GITHUB_SSH_PREFIX}:" _bd_url "${_bd_url}")
+        endif( )
+
         # TODO: In the future, this might need to be generalized more to
         #       accommodate those who use multiple accounts with SSH keys
         #       associated with them. In these situations, the string
@@ -47,7 +51,7 @@ cpp_class(GitHubDependency Dependency)
         #       REGEX MATCH below should do this, but the `cmaize_sanitize_url`
         #       function also must be redesigned for these URLs to be allowed.
         # string(REGEX MATCH "^git@[A-Za-z0-9_-]:" _bd_is_ssh "${_bd_url}")
-        string(FIND "${_bd_url}" "git@github.com:" _bd_is_ssh)
+        string(FIND "${_bd_url}" "${CMAIZE_GITHUB_SSH_PREFIX}:" _bd_is_ssh)
 
         # Determine what type of URL to generate to access the repository
         if(_bd_is_ssh GREATER -1)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**

Resolves https://github.com/CMakePP/CMaize/issues/107

**Description**

Enables default SSH access for private GitHub repositories by adding `CMAIZE_GITHUB_USE_SSH` and `CMAIZE_GITHUB_SSH_PREFIX`

