### PR TITLE
Documentation warnings

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -66,7 +66,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -165,7 +165,7 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for todo extension ----------------------------------------------
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
When building the documentation, there is a warning about `language = None` being invalid: `WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).` There is also a warning that we are using a deprecated format for `intersphinx_mapping`.

This PR sets `language` to the default `'en'` to remove the warning. I have also updated the `intersphinx_mapping` formatting to the new version according to the [Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping).
