### PR TITLE
Rename 'ProjectSpecification' to 'PackageSpecification'

### DIFF
--- a/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
+++ b/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
@@ -131,8 +131,8 @@ cpp_class(CMakePackageManager PackageManager)
     #
     # :param _fi_result: Return value for the installed target.
     # :type _fi_result: InstalledTarget*
-    # :param _fi_project_specs: Specifications for the package to build.
-    # :type _fi_project_specs: PackageSpecification
+    # :param _fi_package_specs: Specifications for the package to build.
+    # :type _fi_package_specs: PackageSpecification
     # :param **kwargs: Additional keyword arguments may be necessary.
     #
     # :Keyword Arguments:
@@ -148,7 +148,7 @@ cpp_class(CMakePackageManager PackageManager)
     cpp_member(find_installed
         CMakePackageManager desc PackageSpecification args
     )
-    function("${find_installed}" self _fi_result _fi_project_specs)
+    function("${find_installed}" self _fi_result _fi_package_specs)
 
         # set(_fi_one_value_args BUILD_TARGET FIND_TARGET NAME URL VERSION)
         set(_fi_one_value_args BUILD_TARGET FIND_TARGET)

--- a/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
+++ b/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
@@ -4,7 +4,7 @@ include(cmakepp_lang/cmakepp_lang)
 include(cmaize/package_managers/package_manager)
 include(cmaize/package_managers/get_package_manager)
 include(cmaize/package_managers/cmake/dependency/dependency)
-include(cmaize/project/project_specification)
+include(cmaize/project/package_specification)
 include(cmaize/targets/cmaize_target)
 include(cmaize/utilities/fetch_and_available)
 include(cmaize/utilities/generated_by_cmaize)
@@ -99,12 +99,12 @@ cpp_class(CMakePackageManager PackageManager)
     # :rtype: Dependency
     #]]
     cpp_member(register_dependency
-        CMakePackageManager desc ProjectSpecification args
+        CMakePackageManager desc PackageSpecification args
     )
     function("${register_dependency}" self _rd_result _rd_proj_specs)
 
-        ProjectSpecification(GET "${_rd_proj_specs}" _rd_pkg_name name)
-        ProjectSpecification(GET "${_rd_proj_specs}" _rd_pkg_version version)
+        PackageSpecification(GET "${_rd_proj_specs}" _rd_pkg_name name)
+        PackageSpecification(GET "${_rd_proj_specs}" _rd_pkg_version version)
 
         CMakePackageManager(GET "${self}" _rd_dependencies dependencies)
         cpp_map(GET "${_rd_dependencies}" _rd_depend "${_rd_pkg_name}")
@@ -132,7 +132,7 @@ cpp_class(CMakePackageManager PackageManager)
     # :param _fi_result: Return value for the installed target.
     # :type _fi_result: InstalledTarget*
     # :param _fi_project_specs: Specifications for the package to build.
-    # :type _fi_project_specs: ProjectSpecification
+    # :type _fi_project_specs: PackageSpecification
     # :param **kwargs: Additional keyword arguments may be necessary.
     #
     # :Keyword Arguments:
@@ -146,7 +146,7 @@ cpp_class(CMakePackageManager PackageManager)
     # :rtype: InstalledTarget
     #]]
     cpp_member(find_installed
-        CMakePackageManager desc ProjectSpecification args
+        CMakePackageManager desc PackageSpecification args
     )
     function("${find_installed}" self _fi_result _fi_project_specs)
 
@@ -156,7 +156,7 @@ cpp_class(CMakePackageManager PackageManager)
             _fi "" "${_fi_one_value_args}" "" ${ARGN}
         )
 
-        ProjectSpecification(GET "${_fi_project_specs}" _fi_pkg_name name)
+        PackageSpecification(GET "${_fi_project_specs}" _fi_pkg_name name)
 
         CMakePackageManager(register_dependency
             "${self}"
@@ -202,12 +202,12 @@ cpp_class(CMakePackageManager PackageManager)
     # :param _gp_result: Resulting target object return variable
     # :type _gp_result: InstalledTarget*
     # :param _gp_proj_specs: Specifications for the package to build.
-    # :type _gp_proj_specs: ProjectSpecification
+    # :type _gp_proj_specs: PackageSpecification
     #
     # :returns: Resulting target from the package manager
     # :rtype: InstalledTarget
     #]]
-    cpp_member(get_package CMakePackageManager str ProjectSpecification args)
+    cpp_member(get_package CMakePackageManager str PackageSpecification args)
     function("${get_package}" self _gp_result _gp_proj_specs)
 
         CMakePackageManager(register_dependency

--- a/cmake/cmaize/package_managers/cmake/dependency/dependency_class.cmake
+++ b/cmake/cmaize/package_managers/cmake/dependency/dependency_class.cmake
@@ -121,7 +121,7 @@ cpp_class(Dependency)
     # Initialize the dependency with project information.
     #
     # TODO: Many of these optional arguments could be contained in a
-    #       ProjectSpecification and seem necessary, not optional, to include
+    #       PackageSpecification and seem necessary, not optional, to include
     #       for this class to work. I need to look into it more.
     #
     # :param **kwargs: Additional keyword arguments may be necessary.

--- a/cmake/cmaize/package_managers/package_manager.cmake
+++ b/cmake/cmaize/package_managers/package_manager.cmake
@@ -19,20 +19,20 @@ cpp_class(PackageManager)
     #[[[
     # Virtual member to check if the package exists in the package manager.
     #]]
-    cpp_member(has_package PackageManager desc ProjectSpecification)
+    cpp_member(has_package PackageManager desc PackageSpecification)
     cpp_virtual_member(has_package)
 
     #[[[
     # Virtual member function to get an installed package target.
     #]]
-    cpp_member(find_installed PackageManager desc ProjectSpecification)
+    cpp_member(find_installed PackageManager desc PackageSpecification)
     cpp_virtual_member(find_installed)
 
     #[[[
     # Virtual member function to get the package source and prepare a
     # build target.
     #]]
-    cpp_member(fetch_package PackageManager desc ProjectSpecification)
+    cpp_member(fetch_package PackageManager desc PackageSpecification)
     cpp_virtual_member(fetch_package)
 
     #[[[

--- a/cmake/cmaize/project/cmaize_project.cmake
+++ b/cmake/cmaize/project/cmaize_project.cmake
@@ -2,7 +2,7 @@ include_guard()
 include(cmakepp_lang/cmakepp_lang)
 
 include(cmaize/targets/cmaize_target)
-include(cmaize/project/project_specification)
+include(cmaize/project/package_specification)
 include(cmaize/utilities/utilities)
 
 #[[[
@@ -35,7 +35,7 @@ cpp_class(CMaizeProject)
     cpp_attr(CMaizeProject name)
 
     #[[[
-    # :type: ProjectSpecification
+    # :type: PackageSpecification
     #
     # Details about the project.
     #]]
@@ -84,7 +84,7 @@ cpp_class(CMaizeProject)
     #    * **VERSION** (*desc*) --
     #      Version string of non-negative integers of the form
     #      ``<major>[.<minor>[.<patch>[.<tweak>] ] ]``. Populates the
-    #      version attributes of the ``ProjectSpecification``. Parallels
+    #      version attributes of the ``PackageSpecification``. Parallels
     #      the ``VERSION <version>`` keyword for CMake ``project()``
     #      (`link <cmake_project_>`__), and the value is passed to
     #      a CMake ``project()`` call if the project does not exist yet.
@@ -151,9 +151,9 @@ cpp_class(CMaizeProject)
             )
         endif()
 
-        # Create a project specification that defaults to the values set
+        # Create a package specification that defaults to the values set
         # in the above ``project()`` call
-        ProjectSpecification(CTOR proj_spec)
+        PackageSpecification(CTOR proj_spec)
         CMaizeProject(SET "${self}" specification "${proj_spec}")
 
     endfunction()

--- a/cmake/cmaize/project/package_specification.cmake
+++ b/cmake/cmaize/project/package_specification.cmake
@@ -5,57 +5,57 @@ include(cmaize/toolchain/toolchain)
 include(cmaize/utilities/utilities)
 
 #[[[
-# The ``ProjectSpecification`` class is envisioned as holding all of the
+# The ``PackageSpecification`` class is envisioned as holding all of the
 # details about how to build a project ("project" being a catchall for a
 # dependency or the project that the CMaize build system is being written
 # for). This includes things like where the source code lives, the version
 # to build, and specific options for configuring and compiling.
-# ``ProjectSpecification`` instances will ultimately be used to request
+# ``PackageSpecification`` instances will ultimately be used to request
 # packages from the ``PackageManager``.
 #]]
-cpp_class(ProjectSpecification)
+cpp_class(PackageSpecification)
     
     #[[[
     # :type: str
     #
     # Name of project or dependency as a string.
     #]]
-    cpp_attr(ProjectSpecification name)
+    cpp_attr(PackageSpecification name)
 
     #[[[
     # :type: str
     #
     # Version of project or dependency as a string.
     #]]
-    cpp_attr(ProjectSpecification version)
+    cpp_attr(PackageSpecification version)
 
     #[[[
     # :type: str
     #
     # First version number component of the ``version`` attribute.
     #]]
-    cpp_attr(ProjectSpecification major_version)
+    cpp_attr(PackageSpecification major_version)
 
     #[[[
     # :type: str
     #
     # Second version number component of the ``version`` attribute.
     #]]
-    cpp_attr(ProjectSpecification minor_version)
+    cpp_attr(PackageSpecification minor_version)
 
     #[[[
     # :type: str
     #
     # Third version number component of the ``version`` attribute.
     #]]
-    cpp_attr(ProjectSpecification patch_version)
+    cpp_attr(PackageSpecification patch_version)
 
     #[[[
     # :type: str
     #
     # Fourth version number component of the ``version`` attribute.
     #]]
-    cpp_attr(ProjectSpecification tweak_version)
+    cpp_attr(PackageSpecification tweak_version)
 
     #[[[
     # :type: str
@@ -78,14 +78,14 @@ cpp_class(ProjectSpecification)
     #    <https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#build-configurations>`__
     #    for more information on the details of making this switch.
     #]]
-    cpp_attr(ProjectSpecification build_type)
+    cpp_attr(PackageSpecification build_type)
 
     #[[[
     # :type: Toolchain
     #
     # User-specified and autopopulated toolchain file values.
     #]]
-    cpp_attr(ProjectSpecification toolchain)
+    cpp_attr(PackageSpecification toolchain)
 
     #[[[
     # :type: cpp_map
@@ -94,7 +94,7 @@ cpp_class(ProjectSpecification)
     #
     # This is initialized to an empty map for users to fill.
     #]]
-    cpp_attr(ProjectSpecification configure_options)
+    cpp_attr(PackageSpecification configure_options)
 
     #[[[
     # :type: cpp_map
@@ -103,23 +103,23 @@ cpp_class(ProjectSpecification)
     #
     # This is initialized to an empty map for users to fill.
     #]]
-    cpp_attr(ProjectSpecification compile_options)
+    cpp_attr(PackageSpecification compile_options)
 
     #[[[
-    # Default constructor for ProjectSpecification object with only
+    # Default constructor for PackageSpecification object with only
     # autopopulated options available.
     #
-    # :param self: ProjectSpecification object constructed.
-    # :type self: ProjectSpecification
+    # :param self: PackageSpecification object constructed.
+    # :type self: PackageSpecification
     # :returns: ``self`` will be set to the newly constructed
-    #           ``ProjectSpecification`` object.
-    # :rtype: ProjectSpecification
+    #           ``PackageSpecification`` object.
+    # :rtype: PackageSpecification
     #]]
-    cpp_constructor(CTOR ProjectSpecification)
+    cpp_constructor(CTOR PackageSpecification)
     function("${CTOR}" self)
 
-        # Initialize the ProjectSpecification object
-        ProjectSpecification(__initialize "${self}")
+        # Initialize the PackageSpecification object
+        PackageSpecification(__initialize "${self}")
 
     endfunction()
 
@@ -130,17 +130,17 @@ cpp_class(ProjectSpecification)
     # ``string(<HASH>`` function defined `here
     # <https://cmake.org/cmake/help/latest/command/string.html#hashing>`__.
     #
-    # :param self: ``ProjectSpecification`` object to hash.
-    # :type self: ProjectSpecification
-    # :param return_hash: Hashed ``ProjectSpecification``
+    # :param self: ``PackageSpecification`` object to hash.
+    # :type self: PackageSpecification
+    # :param return_hash: Hashed ``PackageSpecification``
     # :type return_hash: str
     # :param hash_type: Hash algorithm to use
     # :type hash_type: str
     #
-    # :returns: Hashed ``ProjectSpecification`` object
+    # :returns: Hashed ``PackageSpecification`` object
     # :rtype: str
     #]]
-    cpp_member(hash ProjectSpecification str str)
+    cpp_member(hash PackageSpecification str str)
     function("${hash}" self return_hash hash_type)
 
         cpp_serialize(self_serialized "${self}")
@@ -159,24 +159,24 @@ cpp_class(ProjectSpecification)
     #    
     #    This override is required because of a bug in CMakePPLang.
     #    Currently, CMakePPLang cannot differentiate between
-    #    ``ProjectSpecification(set_version "${ps_obj}")`` and 
-    #    ``ProjectSpecification(set_version "${ps_obj}" "")``. Sometimes the
+    #    ``PackageSpecification(set_version "${ps_obj}")`` and 
+    #    ``PackageSpecification(set_version "${ps_obj}" "")``. Sometimes the
     #    ``PROJECT_VERSION`` variable used in ``__initialize`` to determine
     #    a default project version is blank, so this ensures we do not get
     #    an error about not including the version argument for
-    #    ``cpp_member(set_version ProjectSpecification str)`` calls.
+    #    ``cpp_member(set_version PackageSpecification str)`` calls.
     #
-    # :param self: ``ProjectSpecification`` object.
-    # :type self: ProjectSpecification
+    # :param self: ``PackageSpecification`` object.
+    # :type self: PackageSpecification
     #]]
-    cpp_member(set_version ProjectSpecification)
+    cpp_member(set_version PackageSpecification)
     function("${set_version}" self)
 
-        ProjectSpecification(SET "${self}" version "")
-        ProjectSpecification(SET "${self}" major_version "")
-        ProjectSpecification(SET "${self}" minor_version "")
-        ProjectSpecification(SET "${self}" patch_version "")
-        ProjectSpecification(SET "${self}" tweak_version "")
+        PackageSpecification(SET "${self}" version "")
+        PackageSpecification(SET "${self}" major_version "")
+        PackageSpecification(SET "${self}" minor_version "")
+        PackageSpecification(SET "${self}" patch_version "")
+        PackageSpecification(SET "${self}" tweak_version "")
 
     endfunction()
 
@@ -184,44 +184,44 @@ cpp_class(ProjectSpecification)
     # Set the project version variable and splits the version into 
     # major, minor, patch, and tweak components.
     #
-    # :param self: ``ProjectSpecification`` object.
-    # :type self: ProjectSpecification
+    # :param self: ``PackageSpecification`` object.
+    # :type self: PackageSpecification
     # :param project_version: Full project version string.
     # :type project_version: str
     #]]
-    cpp_member(set_version ProjectSpecification str)
+    cpp_member(set_version PackageSpecification str)
     function("${set_version}" self project_version)
 
         cmaize_split_version(major minor patch tweak "${project_version}")
 
-        ProjectSpecification(SET "${self}" version "${project_version}")
-        ProjectSpecification(SET "${self}" major_version "${major}")
-        ProjectSpecification(SET "${self}" minor_version "${minor}")
-        ProjectSpecification(SET "${self}" patch_version "${patch}")
-        ProjectSpecification(SET "${self}" tweak_version "${tweak}")
+        PackageSpecification(SET "${self}" version "${project_version}")
+        PackageSpecification(SET "${self}" major_version "${major}")
+        PackageSpecification(SET "${self}" minor_version "${minor}")
+        PackageSpecification(SET "${self}" patch_version "${patch}")
+        PackageSpecification(SET "${self}" tweak_version "${tweak}")
 
     endfunction()
 
     #[[[
     # Initialize project attributes with default values.
     #
-    # :param self: ``ProjectSpecification`` object to initialize.
-    # :type self: ProjectSpecification
+    # :param self: ``PackageSpecification`` object to initialize.
+    # :type self: PackageSpecification
     #]]
-    cpp_member(__initialize ProjectSpecification)
+    cpp_member(__initialize PackageSpecification)
     function("${__initialize}" self)
 
         # Get the name from the most recent ``project()`` call
-        ProjectSpecification(SET "${self}" name "${PROJECT_NAME}")
+        PackageSpecification(SET "${self}" name "${PROJECT_NAME}")
         
         # Get the version from the most recent ``project()`` call
-        ProjectSpecification(set_version "${self}" "${PROJECT_VERSION}")
+        PackageSpecification(set_version "${self}" "${PROJECT_VERSION}")
 
-        ProjectSpecification(SET "${self}" build_type "${CMAKE_BUILD_TYPE}")
+        PackageSpecification(SET "${self}" build_type "${CMAKE_BUILD_TYPE}")
 
         # Initialize toolchain using CMAKE_TOOLCHAIN_FILE variable
         Toolchain(CTOR my_toolchain "${CMAKE_TOOLCHAIN_FILE}")
-        ProjectSpecification(SET "${self}" toolchain "${my_toolchain}")
+        PackageSpecification(SET "${self}" toolchain "${my_toolchain}")
 
         # Set the configure_options map to an empty map
         cpp_map(CTOR tmp_configure_options)

--- a/cmake/cmaize/project/package_specification.cmake
+++ b/cmake/cmaize/project/package_specification.cmake
@@ -6,7 +6,7 @@ include(cmaize/utilities/utilities)
 
 #[[[
 # The ``PackageSpecification`` class is envisioned as holding all of the
-# details about how to build a project ("project" being a catchall for a
+# details about how to build a package ("package" being a catchall for a
 # dependency or the project that the CMaize build system is being written
 # for). This includes things like where the source code lives, the version
 # to build, and specific options for configuring and compiling.
@@ -18,14 +18,14 @@ cpp_class(PackageSpecification)
     #[[[
     # :type: str
     #
-    # Name of project or dependency as a string.
+    # Name of package as a string.
     #]]
     cpp_attr(PackageSpecification name)
 
     #[[[
     # :type: str
     #
-    # Version of project or dependency as a string.
+    # Version of package as a string.
     #]]
     cpp_attr(PackageSpecification version)
 
@@ -90,7 +90,7 @@ cpp_class(PackageSpecification)
     #[[[
     # :type: cpp_map
     #
-    # Project configure options.
+    # Package configure options.
     #
     # This is initialized to an empty map for users to fill.
     #]]
@@ -99,7 +99,7 @@ cpp_class(PackageSpecification)
     #[[[
     # :type: cpp_map
     #
-    # Project compile options.
+    # Package compile options.
     #
     # This is initialized to an empty map for users to fill.
     #]]
@@ -152,7 +152,7 @@ cpp_class(PackageSpecification)
     endfunction()
 
     #[[[
-    # Overload to ``set_version()`` method to catch when the project version
+    # Overload to ``set_version()`` method to catch when the package version
     # string is blank.
     #
     # .. note::
@@ -162,7 +162,7 @@ cpp_class(PackageSpecification)
     #    ``PackageSpecification(set_version "${ps_obj}")`` and 
     #    ``PackageSpecification(set_version "${ps_obj}" "")``. Sometimes the
     #    ``PROJECT_VERSION`` variable used in ``__initialize`` to determine
-    #    a default project version is blank, so this ensures we do not get
+    #    a default package version is blank, so this ensures we do not get
     #    an error about not including the version argument for
     #    ``cpp_member(set_version PackageSpecification str)`` calls.
     #
@@ -181,20 +181,20 @@ cpp_class(PackageSpecification)
     endfunction()
 
     #[[[
-    # Set the project version variable and splits the version into 
+    # Set the package version variable and splits the version into 
     # major, minor, patch, and tweak components.
     #
     # :param self: ``PackageSpecification`` object.
     # :type self: PackageSpecification
-    # :param project_version: Full project version string.
-    # :type project_version: str
+    # :param package_version: Full package version string.
+    # :type package_version: str
     #]]
     cpp_member(set_version PackageSpecification str)
-    function("${set_version}" self project_version)
+    function("${set_version}" self package_version)
 
-        cmaize_split_version(major minor patch tweak "${project_version}")
+        cmaize_split_version(major minor patch tweak "${package_version}")
 
-        PackageSpecification(SET "${self}" version "${project_version}")
+        PackageSpecification(SET "${self}" version "${package_version}")
         PackageSpecification(SET "${self}" major_version "${major}")
         PackageSpecification(SET "${self}" minor_version "${minor}")
         PackageSpecification(SET "${self}" patch_version "${patch}")
@@ -203,7 +203,7 @@ cpp_class(PackageSpecification)
     endfunction()
 
     #[[[
-    # Initialize project attributes with default values.
+    # Initialize package attributes with default values.
     #
     # :param self: ``PackageSpecification`` object to initialize.
     # :type self: PackageSpecification

--- a/cmake/cmaize/project/projects.cmake
+++ b/cmake/cmaize/project/projects.cmake
@@ -1,4 +1,4 @@
 include_guard()
 
 include(cmaize/project/cmaize_project)
-include(cmaize/project/project_specification)
+include(cmaize/project/package_specification)

--- a/cmake/cmaize/user_api/find_or_build_dependency.cmake
+++ b/cmake/cmaize/user_api/find_or_build_dependency.cmake
@@ -41,7 +41,7 @@ endfunction()
 #
 # :Keyword Arguments:
 #    * **VERSION** (*desc*) --
-#      Version of the project to find. Defaults to no version ("").
+#      Version of the package to find. Defaults to no version ("").
 #    * **PACKAGE_MANAGER** (*desc*) --
 #      Package manager to use. Must be a valid package listed in the
 #      ``CMAIZE_SUPPORTED_PACKAGE_MANAGERS`` variable. Defaults to "CMake".
@@ -94,10 +94,10 @@ function(cmaize_find_or_build_dependency_cmake _fobdc_name)
 
     cpp_get_global(_fobdc_project CMAIZE_PROJECT_${PROJECT_NAME})
 
-    # Create the project specification
-    PackageSpecification(ctor _fobdc_project_specs)
-    PackageSpecification(SET "${_fobdc_project_specs}" name "${_fobdc_name}")
-    PackageSpecification(set_version "${_fobdc_project_specs}" "${_fobdc_VERSION}")
+    # Create the package specification
+    PackageSpecification(ctor _fobdc_package_specs)
+    PackageSpecification(SET "${_fobdc_package_specs}" name "${_fobdc_name}")
+    PackageSpecification(set_version "${_fobdc_package_specs}" "${_fobdc_VERSION}")
 
     # Add a CMakePackageManager to the project if it does not exist yet
     CMaizeProject(get_package_manager "${_fobdc_project}" _fobdc_pm "CMake")
@@ -114,7 +114,7 @@ function(cmaize_find_or_build_dependency_cmake _fobdc_name)
     CMakePackageManager(find_installed
         "${_fobdc_pm}"
         _fobdc_tgt
-        "${_fobdc_project_specs}"
+        "${_fobdc_package_specs}"
         ${ARGN}
     )
     if(NOT "${_fobdc_tgt}" STREQUAL "")
@@ -131,7 +131,7 @@ function(cmaize_find_or_build_dependency_cmake _fobdc_name)
     CMakePackageManager(get_package
         "${_fobdc_pm}"
         _fobdc_tgt
-        "${_fobdc_project_specs}"
+        "${_fobdc_package_specs}"
         ${ARGN}
     )
     if(NOT "${_fobdc_tgt}" STREQUAL "")

--- a/cmake/cmaize/user_api/find_or_build_dependency.cmake
+++ b/cmake/cmaize/user_api/find_or_build_dependency.cmake
@@ -95,9 +95,9 @@ function(cmaize_find_or_build_dependency_cmake _fobdc_name)
     cpp_get_global(_fobdc_project CMAIZE_PROJECT_${PROJECT_NAME})
 
     # Create the project specification
-    ProjectSpecification(ctor _fobdc_project_specs)
-    ProjectSpecification(SET "${_fobdc_project_specs}" name "${_fobdc_name}")
-    ProjectSpecification(set_version "${_fobdc_project_specs}" "${_fobdc_VERSION}")
+    PackageSpecification(ctor _fobdc_project_specs)
+    PackageSpecification(SET "${_fobdc_project_specs}" name "${_fobdc_name}")
+    PackageSpecification(set_version "${_fobdc_project_specs}" "${_fobdc_VERSION}")
 
     # Add a CMakePackageManager to the project if it does not exist yet
     CMaizeProject(get_package_manager "${_fobdc_project}" _fobdc_pm "CMake")

--- a/docs/src/developer/design_notes/classes/index.rst
+++ b/docs/src/developer/design_notes/classes/index.rst
@@ -10,6 +10,6 @@ This chapter describes the design of different classes that make up CMaize.
    build_target
    cxx_target
    installed_target
-   project_specification
+   package_specification
    target
    toolchain

--- a/docs/src/developer/design_notes/classes/package_specification.rst
+++ b/docs/src/developer/design_notes/classes/package_specification.rst
@@ -1,30 +1,30 @@
 **************************
-ProjectSpecification Class
+PackageSpecification Class
 **************************
 
-The ``ProjectSpecification`` class is envisioned as holding all of the
+The ``PackageSpecification`` class is envisioned as holding all of the
 details about how to build a project ("project" being a catchall for a
 dependency or the project that the CMaize build system is being written
 for). This includes things like where the source code lives, the version
 to build, and specific options for configuring and compiling.
-``ProjectSpecification`` instances will ultimately be used to request
+``PackageSpecification`` instances will ultimately be used to request
 packages from the ``PackageManager`` and inform ``CMaizeTarget`` classes.
 
 Usage
 =====
 
-Creating a ProjectSpecification
+Creating a PackageSpecification
 -------------------------------
 
-One constructor is provided to create an instance of ``ProjectSpecification``,
+One constructor is provided to create an instance of ``PackageSpecification``,
 which will contain some default values determined for your system, with:
 
 .. code-block:: cmake
 
-   # Create ProjectSpecification object
-   ProjectSpecification(ps_obj)
+   # Create PackageSpecification object
+   PackageSpecification(ps_obj)
 
-Modifying a ProjectSpecification
+Modifying a PackageSpecification
 --------------------------------
 
 After a default instance is created, most attributes should be accessed and
@@ -32,8 +32,8 @@ modified using CMakePPLang object `getters and setters
 <https://cmakepp.github.io/CMakePPLang/features/classes.html
 #getting-and-setting-attributes>`__. However, to ensure that all version
 component variables are set correctly, you should use the
-``ProjectSpecification(set_version`` method to set a project version.
+``PackageSpecification(set_version`` method to set a project version.
 
 At the moment, the ``configure_options`` and ``compile_options`` attributes
-are not populated by ``ProjectSpecification``. These maps are available for
-classes using ``ProjectSpecification`` to populate with relevant information.
+are not populated by ``PackageSpecification``. These maps are available for
+classes using ``PackageSpecification`` to populate with relevant information.

--- a/docs/src/developer/design_notes/classes/package_specification.rst
+++ b/docs/src/developer/design_notes/classes/package_specification.rst
@@ -3,8 +3,8 @@ PackageSpecification Class
 **************************
 
 The ``PackageSpecification`` class is envisioned as holding all of the
-details about how to build a project ("project" being a catchall for a
-dependency or the project that the CMaize build system is being written
+details about how to build a package ("package" being a catchall for a
+dependency or the package that the CMaize build system is being written
 for). This includes things like where the source code lives, the version
 to build, and specific options for configuring and compiling.
 ``PackageSpecification`` instances will ultimately be used to request
@@ -32,7 +32,7 @@ modified using CMakePPLang object `getters and setters
 <https://cmakepp.github.io/CMakePPLang/features/classes.html
 #getting-and-setting-attributes>`__. However, to ensure that all version
 component variables are set correctly, you should use the
-``PackageSpecification(set_version`` method to set a project version.
+``PackageSpecification(set_version`` method to set a package version.
 
 At the moment, the ``configure_options`` and ``compile_options`` attributes
 are not populated by ``PackageSpecification``. These maps are available for

--- a/tests/cmaize/package_managers/cmake/test_cmake_package_manager.cmake
+++ b/tests/cmaize/package_managers/cmake/test_cmake_package_manager.cmake
@@ -6,7 +6,7 @@ include(cmake_test/cmake_test)
 ct_add_test(NAME "test_cmake_package_manager")
 function("${test_cmake_package_manager}")
     include(cmaize/package_managers/cmake/cmake)
-    include(cmaize/project/project_specification)
+    include(cmaize/project/package_specification)
 
     ct_add_section(NAME "type_is_cmake")
     function("${type_is_cmake}")
@@ -110,9 +110,9 @@ function("${test_cmake_package_manager}")
     # ct_add_section(NAME "can_find_git")
     # function("${can_find_git}")
 
-    #     ProjectSpecification(CTOR ps_obj)
-    #     ProjectSpecification(SET "${ps_obj}" name "Git")
-    #     ProjectSpecification(SET "${ps_obj}" version "2.17.1")
+    #     PackageSpecification(CTOR ps_obj)
+    #     PackageSpecification(SET "${ps_obj}" name "Git")
+    #     PackageSpecification(SET "${ps_obj}" version "2.17.1")
 
     #     CMakePackageManager(CTOR pm_obj)
 
@@ -125,8 +125,8 @@ function("${test_cmake_package_manager}")
     # ct_add_section(NAME "can_find_git")
     # function("${can_find_git}")
 
-    #     ProjectSpecification(CTOR ps_obj)
-    #     ProjectSpecification(SET "${ps_obj}" name "utilities")
+    #     PackageSpecification(CTOR ps_obj)
+    #     PackageSpecification(SET "${ps_obj}" name "utilities")
 
     #     CMakePackageManager(CTOR pm_obj)
     #     CMakePackageManager(add_paths "${pm_obj}" "/home/zachcran/programs/cmakepp_workspace/test_repos/nwx_utilities/install")

--- a/tests/cmaize/project/test_cmaize_project.cmake
+++ b/tests/cmaize/project/test_cmaize_project.cmake
@@ -36,8 +36,8 @@ function("${test_project}")
 
             CMaizeProject(GET "${proj_obj}" result_name name)
             CMaizeProject(GET "${proj_obj}" specs specification)
-            ProjectSpecification(GET "${specs}" spec_name name)
-            ProjectSpecification(GET "${specs}" spec_version version)
+            PackageSpecification(GET "${specs}" spec_name name)
+            PackageSpecification(GET "${specs}" spec_version version)
 
             # Test name
             ct_assert_equal(result_name "${proj_name}")
@@ -74,8 +74,8 @@ function("${test_project}")
             CMaizeProject(GET "${proj_obj}" result_name name)
             CMaizeProject(GET "${proj_obj}" result_languages languages)
             CMaizeProject(GET "${proj_obj}" specs specification)
-            ProjectSpecification(GET "${specs}" spec_name name)
-            ProjectSpecification(GET "${specs}" spec_version version)
+            PackageSpecification(GET "${specs}" spec_name name)
+            PackageSpecification(GET "${specs}" spec_version version)
 
             # Test name
             ct_assert_equal(result_name "${proj_name}")

--- a/tests/cmaize/project/test_package_specification.cmake
+++ b/tests/cmaize/project/test_package_specification.cmake
@@ -1,11 +1,11 @@
 include(cmake_test/cmake_test)
 
 #[[[
-# Test the functionalities of the ProjectSpecification class.
+# Test the functionalities of the PackageSpecification class.
 #]]
-ct_add_test(NAME "test_project_specification")
-function("${test_project_specification}")
-    include(cmaize/project/project_specification)
+ct_add_test(NAME "test_package_specification")
+function("${test_package_specification}")
+    include(cmaize/project/package_specification)
 
     #[[[
     # Test that the constructor is working with different arguments.
@@ -22,10 +22,10 @@ function("${test_project_specification}")
         function("${empty_toolchain}")
 
             # Create a toolchain object with no user options
-            ProjectSpecification(CTOR ps_obj)
+            PackageSpecification(CTOR ps_obj)
 
             # The file content should be blank
-            ProjectSpecification(GET "${ps_obj}" _ps name version build_type)
+            PackageSpecification(GET "${ps_obj}" _ps name version build_type)
             ct_assert_equal(_ps_name "${PROJECT_NAME}")
             ct_assert_equal(_ps_version "${PROJECT_VERSION}")
             ct_assert_equal(_ps_build_type "${CMAKE_BUILD_TYPE}")
@@ -41,13 +41,13 @@ function("${test_project_specification}")
     function("${test_set_version}")
 
         # Create a toolchain object with no user options
-        ProjectSpecification(CTOR ps_obj)
+        PackageSpecification(CTOR ps_obj)
 
         # Set the version to a reasonable value
-        ProjectSpecification(set_version "${ps_obj}" "3.15.5.2-alpha")
+        PackageSpecification(set_version "${ps_obj}" "3.15.5.2-alpha")
 
         # Get the version variables
-        ProjectSpecification(GET "${ps_obj}" _ps
+        PackageSpecification(GET "${ps_obj}" _ps
             version
             major_version
             minor_version
@@ -74,10 +74,10 @@ function("${test_project_specification}")
         function("${bad_hash_type}")
 
             # Create a toolchain object with no user options
-            ProjectSpecification(CTOR ps_obj)
+            PackageSpecification(CTOR ps_obj)
 
             # Hash the object
-            ProjectSpecification(hash "${ps_obj}" hash "bad_type")
+            PackageSpecification(hash "${ps_obj}" hash "bad_type")
 
             # This should throw in one way or another
 
@@ -93,10 +93,10 @@ function("${test_project_specification}")
             set(corr_hash "f045215c1d2d14bd3d4fcfd71c009fed40bd2dfc")
 
             # Create a toolchain object with no user options
-            ProjectSpecification(CTOR ps_obj)
+            PackageSpecification(CTOR ps_obj)
 
             # Hash the object
-            ProjectSpecification(hash "${ps_obj}" returned_hash "SHA1")
+            PackageSpecification(hash "${ps_obj}" returned_hash "SHA1")
 
             # SHA1 produces hash strings of length 40
             string(LENGTH "${returned_hash}" hash_length)
@@ -119,19 +119,19 @@ function("${test_project_specification}")
         function("${valid_hash_types}")
 
             # Create a toolchain object with no user options
-            ProjectSpecification(CTOR ps_obj)
+            PackageSpecification(CTOR ps_obj)
 
             # Hash the object
-            ProjectSpecification(hash "${ps_obj}" return_hash "MD5")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA1")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA224")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA256")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA384")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA512")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA3_224")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA3_256")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA3_384")
-            ProjectSpecification(hash "${ps_obj}" return_hash "SHA3_512")
+            PackageSpecification(hash "${ps_obj}" return_hash "MD5")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA1")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA224")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA256")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA384")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA512")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA3_224")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA3_256")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA3_384")
+            PackageSpecification(hash "${ps_obj}" return_hash "SHA3_512")
 
         endfunction()
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Issue #111.

**Description**
Renames the `ProjectSpecification` class to `PackageSpecification`.

**TODOs**
- [x] Initial find-and-replace of `ProjectSpecification` -> `PackageSpecification` and `project_specification` to `package_specification`.
- [x] Rename files in the source code, tests, and documentation.
- [x] Do a project-wide search for "project" to see if any mentions were missed in documentation.
