### PR TITLE
Remaining ci and cleanup

### DIFF
--- a/.github/workflows/add_licenses.yml
+++ b/.github/workflows/add_licenses.yml
@@ -1,0 +1,28 @@
+# Copyright 2021 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Add Licenses
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  license_files:
+    uses: CMakePP/.github/.github/workflows/add_licenses_master.yaml@main
+    with:
+      config_file: .github/.licenserc.yaml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,0 +1,27 @@
+# Copyright 2021 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Tag and Release
+
+on:
+  pull_request:
+    types:
+      - closed # N.B. below we check that it was merged too
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    uses: CMakePP/.github/.github/workflows/tag_and_release_master.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
-# Common CLion build directories
-cmake-build-*
-
-# CLion settings
+# IDE settings
 .idea/
+.vscode/
 
 # Build directories
-build
+**/*build*/
+
+# Install directories
+**/*install*/
+
+# Python virtual environments
+**/*venv*/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 # Build directories
 **/*build*/
+## API documentation build directory
+docs/src/api/developer/
 
 # Install directories
 **/*install*/


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Closes #61.

**Description**
This PR finishes adding CI for automated semantic versioning and adding license headers to files. It also does some minor cleanup to the `.github` file.

**Note:** The CI is pulled directly from CMakePPLang's CI workflow files.

**TODOs**
- [x] Add semantic versioning CI.
- [x] Add license header CI.
