### PR TITLE
Fix missed rename from ProjectSpecification to PackageSpecification

### DIFF
--- a/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
+++ b/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
@@ -156,12 +156,12 @@ cpp_class(CMakePackageManager PackageManager)
             _fi "" "${_fi_one_value_args}" "" ${ARGN}
         )
 
-        PackageSpecification(GET "${_fi_project_specs}" _fi_pkg_name name)
+        PackageSpecification(GET "${_fi_package_specs}" _fi_pkg_name name)
 
         CMakePackageManager(register_dependency
             "${self}"
             _fi_depend
-            "${_fi_project_specs}"
+            "${_fi_package_specs}"
             ${ARGN}
         )
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Leftovers from #111.

**Description**
This PR fixes a few places that were missed in the initial rename from `ProjectSpecification` to `PackageSpecification`.
