### PR TITLE
Fix hard-coded lib path in *-targets.cmake files

### DIFF
--- a/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
+++ b/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
@@ -706,7 +706,7 @@ set_target_properties(${__gtc_namespace}${__gtc_target_name} PROPERTIES
         string(APPEND
             __gtc_file_contents
             "
-set(_CMAIZE_IMPORT_LOCATION \"\${PACKAGE_PREFIX_DIR}/lib/${__gtc_target_name}/${__gtc_libname_w_version}\")
+set(_CMAIZE_IMPORT_LOCATION \"\${PACKAGE_PREFIX_DIR}/${CMAKE_INSTALL_LIBDIR}/${__gtc_target_name}/${__gtc_libname_w_version}\")
 
 # Import target \"${__gtc_namespace}${__gtc_target_name}\" for configuration \"???\"
 set_property(TARGET ${__gtc_namespace}${__gtc_target_name} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
When `_CMAIZE_IMPORT_LOCATION` is configured in a `<package>-targets.cmake` file, it is hard-coded to use the library directory `lib`. This can change based on the system you are on to `lib64`, so we need to account for that change. This PR fixes it to use the value of `CMAKE_INSTALL_LIBDIR` from `include(GNUInstallDirs)` ([link](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html)).

**TODOs**
- [x] None.
- [x] This was tested on `perlmutter` and fixed the issue for Andres.
