### PR TITLE
Enable integration tests on Mac systems

### DIFF
--- a/tests/scripts/test_CMaizePrivateDepend.sh
+++ b/tests/scripts/test_CMaizePrivateDepend.sh
@@ -79,10 +79,16 @@ build_and_install $PACKAGE ${log_dir} $TOOLCHAIN $WORKSPACE/install \
 # Verify that the installation was successful
 echo "Verifying package installation..."
 
+version="1.0.0"
+libext="so.$version"
+if [[ "`uname`" == 'Darwin' ]]; then
+    libext=$version.dylib
+fi
+
 check_dir_exists  "install/include/cmaize_private_depend"
 check_file_exists "install/include/cmaize_private_depend/cmaize_private_depend.hpp"
 check_dir_exists  "install/lib/$PACKAGE"
-check_file_exists "install/lib/$PACKAGE/lib${PACKAGE}.so.1.0.0"
+check_file_exists "install/lib/$PACKAGE/lib${PACKAGE}.$libext"
 check_dir_exists  "install/lib/$PACKAGE/cmake"
 check_file_exists "install/lib/$PACKAGE/cmake/${PACKAGE}Config.cmake"
 check_file_exists "install/lib/$PACKAGE/cmake/${PACKAGE}ConfigVersion.cmake"

--- a/tests/scripts/test_CMaizePrivateDepend2.sh
+++ b/tests/scripts/test_CMaizePrivateDepend2.sh
@@ -80,10 +80,16 @@ build_and_install $PACKAGE ${log_dir} $TOOLCHAIN $WORKSPACE/install \
 # Verify that the installation was successful
 echo "Verifying package installation..."
 
+version="1.0.0"
+libext="so.$version"
+if [[ "`uname`" == 'Darwin' ]]; then
+    libext=$version.dylib
+fi
+
 check_dir_exists  "install/include/cmaize_private_depend_2"
 check_file_exists "install/include/cmaize_private_depend_2/cmaize_private_depend_2.hpp"
 check_dir_exists  "install/lib/$PACKAGE"
-check_file_exists "install/lib/$PACKAGE/lib${PACKAGE}.so.1.0.0"
+check_file_exists "install/lib/$PACKAGE/lib${PACKAGE}.$libext"
 check_dir_exists  "install/lib/$PACKAGE/cmake"
 check_file_exists "install/lib/$PACKAGE/cmake/${PACKAGE}Config.cmake"
 check_file_exists "install/lib/$PACKAGE/cmake/${PACKAGE}ConfigVersion.cmake"

--- a/tests/scripts/test_CMaizePublicDepend.sh
+++ b/tests/scripts/test_CMaizePublicDepend.sh
@@ -78,10 +78,16 @@ build_and_install $PACKAGE ${log_dir} $TOOLCHAIN $WORKSPACE/install \
 # Verify that the installation was successful
 echo "Verifying package installation..."
 
+version="1.0.0"
+libext="so.$version"
+if [[ "`uname`" == 'Darwin' ]]; then
+    libext=$version.dylib
+fi
+
 check_dir_exists  "install/include/cmaize_public_depend"
 check_file_exists "install/include/cmaize_public_depend/cmaize_public_depend.hpp"
 check_dir_exists  "install/lib/$PACKAGE"
-check_file_exists "install/lib/$PACKAGE/lib${PACKAGE}.so.1.0.0"
+check_file_exists "install/lib/$PACKAGE/lib${PACKAGE}.$libext"
 check_dir_exists  "install/lib/$PACKAGE/cmake"
 check_file_exists "install/lib/$PACKAGE/cmake/${PACKAGE}Config.cmake"
 check_file_exists "install/lib/$PACKAGE/cmake/${PACKAGE}ConfigVersion.cmake"

--- a/tests/scripts/test_CMaizePublicDepend2.sh
+++ b/tests/scripts/test_CMaizePublicDepend2.sh
@@ -79,10 +79,16 @@ build_and_install $PACKAGE ${log_dir} $TOOLCHAIN $WORKSPACE/install \
 # Verify that the installation was successful
 echo "Verifying package installation..."
 
+version="1.0.0"
+libext="so.$version"
+if [[ "`uname`" == 'Darwin' ]]; then
+    libext=$version.dylib
+fi
+
 check_dir_exists  "install/include/cmaize_public_depend_2"
 check_file_exists "install/include/cmaize_public_depend_2/cmaize_public_depend_2.hpp"
 check_dir_exists  "install/lib/$PACKAGE"
-check_file_exists "install/lib/$PACKAGE/lib${PACKAGE}.so.1.0.0"
+check_file_exists "install/lib/$PACKAGE/lib${PACKAGE}.$libext"
 check_dir_exists  "install/lib/$PACKAGE/cmake"
 check_file_exists "install/lib/$PACKAGE/cmake/${PACKAGE}Config.cmake"
 check_file_exists "install/lib/$PACKAGE/cmake/${PACKAGE}ConfigVersion.cmake"

--- a/tests/scripts/test_CMakePrivate.sh
+++ b/tests/scripts/test_CMakePrivate.sh
@@ -81,9 +81,14 @@ build_and_install $PACKAGE ${log_dir} $TOOLCHAIN $WORKSPACE/install \
 # Verify that the installation was successful
 echo "Verifying package installation..."
 
+libext="so"
+if [[ "`uname`" == 'Darwin' ]]; then
+    libext=dylib
+fi
+
 check_dir_exists  "install/include/cmake_private"
 check_file_exists "install/include/cmake_private/cmake_private.hpp"
 check_dir_exists  "install/lib/cmakeprivate"
-check_file_exists "install/lib/cmakeprivate/libCMakePrivate.so"
+check_file_exists "install/lib/cmakeprivate/libCMakePrivate.$libext"
 check_dir_exists  "install/lib/cmakeprivate/cmake"
 check_file_exists "install/lib/cmakeprivate/cmake/${PACKAGE}Config.cmake"

--- a/tests/scripts/test_CMakePublic.sh
+++ b/tests/scripts/test_CMakePublic.sh
@@ -79,11 +79,16 @@ build_and_install $PACKAGE ${log_dir} $TOOLCHAIN $WORKSPACE/install \
 # Verify that the installation was successful
 echo "Verifying package installation..."
 
+libext="so"
+if [[ "`uname`" == 'Darwin' ]]; then
+    libext=dylib
+fi
+
 check_dir_exists  "install/include/cmake_public"
 check_file_exists "install/include/cmake_public/cmake_public.hpp"
 check_dir_exists  "install/lib/CMakePublic"
-check_file_exists "install/lib/CMakePublic/libhello.so"
-check_file_exists "install/lib/CMakePublic/libworld.so"
+check_file_exists "install/lib/CMakePublic/libhello.$libext"
+check_file_exists "install/lib/CMakePublic/libworld.$libext"
 check_dir_exists  "install/lib/CMakePublic/cmake"
 check_file_exists "install/lib/CMakePublic/cmake/${PACKAGE}Config.cmake"
 check_file_exists "install/lib/CMakePublic/cmake/helloConfig.cmake"


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Currently, shared library file extensions are hard-coded in the integration tests for Linux systems. Mac systems generate different shared library file extensions, so the integration tests fail on Mac. This PR updates the integration test scripts to detect if they are running on a Mac and use the appropriate file extensions.

**TODOs**
- [x] Ensure that integration tests work on Mac.
- [x] Ensure that integration tests still work on Linux.
