### PR TITLE
Adds find_dependency

### DIFF
--- a/cmake/cmaize/project/cmaize_project.cmake
+++ b/cmake/cmaize/project/cmaize_project.cmake
@@ -17,6 +17,7 @@ include(cmakepp_lang/cmakepp_lang)
 
 include(cmaize/targets/cmaize_target)
 include(cmaize/project/package_specification)
+include(cmaize/project/impl_/impl_)
 include(cmaize/utilities/utilities)
 
 #[[[
@@ -310,90 +311,9 @@ cpp_class(CMaizeProject)
     cpp_member(add_target CMaizeProject str CMaizeTarget args)
     function("${add_target}" self _at_target_name _at_target)
 
-        CMaizeProject(_add_target
+        _add_target(
             "${self}" "${_at_target}" NAME "${_at_target_name}" ${ARGN}
         )
-
-    endfunction()
-
-    #[[[
-    # Add a target to the project. Duplicate objects will not be added.
-    #
-    # This internal implementation exists so a required keyword argument is
-    # not part of the public interface, as well as to handle both ``desc`` and
-    # ``target`` types. Both types are effectively strings representing target
-    # names in this algorithm and can be treated equivalently, but cannot be
-    # typecast to each other by CMakePPLang. The CMakePPLang type checking
-    # is bypassed through the aforementioned required keyword argument for
-    # the target name, essentially combining the two types.
-    #
-    # :param __at_target: CMaizeTarget object to be added.
-    # :type __at_target: CMaizeTarget
-    # :param NAME: Required keyword argument. See description below.
-    # :type NAME: desc or target
-    # :param **kwargs: Additional keyword arguments may be necessary.
-    #
-    # :Keyword Arguments:
-    #    * **INSTALLED** (*bool*) --
-    #      Flag to indicate that the target being added is already installed
-    #      on the system.
-    #    * **NAME** (*desc* or *target*) --
-    #      Identifying name for the target. This can match name of either the
-    #      CMake target or CMaizeTarget object, but is required to do match
-    #      them. This keyword argument is **required**.
-    #]]
-    cpp_member(_add_target CMaizeProject CMaizeTarget args)
-    function("${_add_target}" self __at_target)
-
-        set(__at_options INSTALLED OVERWRITE)
-        set(__at_one_value_args NAME)
-        cmake_parse_arguments(__at "${__at_options}" "${__at_one_value_args}" "" ${ARGN})
-
-        # Ensure that NAME was provided
-        cpp_contains(__at_name_exists __at_NAME "${__at_KEYWORDS_MISSING_VALUES}")
-        if(__at_name_exists)
-            cpp_raise(KeywordMissing "Missing required keyword argument: NAME")
-        endif()
-
-        # Default to the build target list
-        set(__at_tgt_attr "build_targets")
-        if(__at_INSTALLED)
-            set(__at_tgt_attr "installed_targets")
-        endif()
-
-        # Check if a CMaizeTarget with the same name exists already as either
-        # a build or installed target
-        CMaizeProject(check_target "${self}" __at_found "${__at_NAME}" ALL)
-
-        # Determine what to do if a target in the project al
-        if(__at_found)            
-            # Exit early if a target with the same name already exists
-            if(NOT __at_OVERWRITE)
-                cpp_return("")
-            endif()
-
-            CMaizeProject(check_target "${self}" __at_build "${__at_NAME}")
-            CMaizeProject(check_target "${self}" __at_install "${__at_NAME}" INSTALLED)
-
-            if(__at_build)
-                CMaizeProject(GET "${self}" __at_tgt_map "build_targets")
-
-                # We cannot easily remove a key from a map, so the best option
-                # is to just clear the value
-                cpp_map(SET "${__at_tgt_map}" "${__at_NAME}" "")
-            endif()
-
-            if (__at_install)
-                CMaizeProject(GET "${self}" __at_tgt_map "installed_targets")
-
-                cpp_map(SET "${__at_tgt_map}" "${__at_NAME}" "")
-            endif()
-        endif()
-
-        # Add the target to the map
-        CMaizeProject(GET "${self}" __at_tgt_map "${__at_tgt_attr}")
-
-        cpp_map(SET "${__at_tgt_map}" "${__at_NAME}" "${__at_target}")
 
     endfunction()
 
@@ -450,118 +370,10 @@ cpp_class(CMaizeProject)
     cpp_member(check_target CMaizeProject desc str args)
     function("${check_target}" self  _ct_found _ct_target_name)
 
-        CMaizeProject(_check_target
+        _check_target(
             "${self}" "${_ct_found}" NAME "${_ct_target_name}" ${ARGN}
         )
         cpp_return("${_ct_found}")
-
-    endfunction()
-
-    #[[[
-    # Checks if a target with the same name is already added to this project.
-    # This defaults to build targets.
-    #
-    # This internal implementation exists so a required keyword argument is
-    # not part of the public interface, as well as to handle both ``desc`` and
-    # ``target`` types. Both types are effectively strings representing target
-    # names in this algorithm and can be treated equivalently, but cannot be
-    # typecast to each other by CMakePPLang. The CMakePPLang type checking
-    # is bypassed through the aforementioned required keyword argument for
-    # the target name, essentially combining the two types.
-    #
-    # :param __ct_found: Return variable for whether the target was found.
-    # :type __ct_found: bool*
-    # :param NAME: Required keyword argument. See description below.
-    # :type NAME: desc or target
-    # :param **kwargs: Additional keyword arguments may be necessary.
-    #
-    # :Keyword Arguments:
-    #    * **INSTALLED** (*bool*) --
-    #      Flag to indicate that the installed targets should be checked.
-    #    * **ALL** (*bool*) --
-    #      Flag to indicate that both the build and installed targets should
-    #      be checked.
-    #    * **NAME** (*desc* or *target*) --
-    #      Identifying name for a target contained in the current Cmaize
-    #      project. This keyword argument is **required**.
-    #
-    # :returns: CMaizeTarget found (TRUE) or not (FALSE).
-    # :rtype: bool
-    #]]
-    cpp_member(_check_target CMaizeProject desc args)
-    function("${_check_target}" self  __ct_found)
-
-        set(__ct_options INSTALLED ALL)
-        set(__ct_one_value_args NAME)
-        cmake_parse_arguments(
-            __ct "${__ct_options}" "${__ct_one_value_args}" "" ${ARGN}
-        )
-
-        # Ensure that NAME was provided
-        cpp_contains(
-            __ct_name_exists __ct_NAME "${__ct_KEYWORDS_MISSING_VALUES}"
-        )
-        if(__ct_name_exists)
-            cpp_raise(KeywordMissing "Missing required keyword argument: NAME")
-        endif()
-
-        # Default to the build target list
-        set(__ct_tgt_attr "build_targets")
-        if(__ct_ALL)
-            # Search both lists
-            list(APPEND __ct_tgt_attr "installed_targets")
-        elseif(__ct_INSTALLED)
-            set(__ct_tgt_attr "installed_targets")
-        endif()
-
-        foreach(__ct_tgt_attr_i ${__ct_tgt_attr})
-            # Get the collection of targets
-            CMaizeProject(GET "${self}" __ct_tgt_map "${__ct_tgt_attr_i}")
-
-            # We check if the key exists here, but that is not sufficient
-            # to know if the value is valid if the key exists. It is possible
-            # from CMaizeProject(add_target for the key to exist but the value
-            # to be blank since we cannot easily remove keys from a map
-            cpp_map(KEYS "${__ct_tgt_map}" __ct_keys)
-            cpp_contains(__ct_key_found_i "${__ct_NAME}" "${__ct_keys}")
-
-            # Initially, set whether the key was found and whether the target
-            # was found to the same value, but this may change in the check
-            # below
-            set(__ct_found_i "${__ct_key_found_i}")
-
-            # Check if a target with the same name already exists
-            # NOTE: Doesn't work for some reason
-            # cpp_map(HAS_KEY "${__ct_tgt_map}" __ct_found_i "${__ct_NAME}")
-
-            # Additional check if the target key exists in the map to ensure
-            # that the target actually exists
-            if(__ct_key_found_i)
-                cpp_map(GET "${__ct_tgt_map}" __ct_key_value_i "${__ct_NAME}")
-
-                cpp_type_of(__ct_key_value_i_type "${__ct_key_value_i}")
-
-                # Check if the value is implicitly convertible to a CMaizeTarget
-                cpp_implicitly_convertible(__ct_is_target_type "${__ct_key_value_i_type}" CMaizeTarget)
-
-                # If it is convertible to a CMaizeTarget, then the target exists
-                set(__ct_found_i "${__ct_is_target_type}")
-
-                # Unless it is an empty string
-                if("${__ct_key_value_i}" STREQUAL "")
-                    set(__ct_found_i FALSE)
-                endif()
-            endif()
-
-            # Return early if target is found
-            if(__ct_found_i)
-                set("${__ct_found}" "${__ct_found_i}")
-                cpp_return("${__ct_found}")
-            endif()
-        endforeach()
-
-        set("${__ct_found}" FALSE)
-        cpp_return("${__ct_found}")
 
     endfunction()
 

--- a/cmake/cmaize/project/impl_/add_target.cmake
+++ b/cmake/cmaize/project/impl_/add_target.cmake
@@ -1,0 +1,99 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+#[[[
+# Add a target to the project. Duplicate objects will not be added.
+#
+# This internal implementation exists so a required keyword argument is
+# not part of the public interface, as well as to handle both ``desc`` and
+# ``target`` types. Both types are effectively strings representing target
+# names in this algorithm and can be treated equivalently, but cannot be
+# typecast to each other by CMakePPLang. The CMakePPLang type checking
+# is bypassed through the aforementioned required keyword argument for
+# the target name, essentially combining the two types.
+#
+# :param __at_target: CMaizeTarget object to be added.
+# :type __at_target: CMaizeTarget
+# :param NAME: Required keyword argument. See description below.
+# :type NAME: desc or target
+# :param **kwargs: Additional keyword arguments may be necessary.
+#
+# :Keyword Arguments:
+#    * **INSTALLED** (*bool*) --
+#      Flag to indicate that the target being added is already installed
+#      on the system.
+#    * **NAME** (*desc* or *target*) --
+#      Identifying name for the target. This can match name of either the
+#      CMake target or CMaizeTarget object, but is required to do match
+#      them. This keyword argument is **required**.
+#]]
+function(_add_target self __at_target)
+
+    set(__at_options INSTALLED OVERWRITE)
+    set(__at_one_value_args NAME)
+    cmake_parse_arguments(
+        __at "${__at_options}" "${__at_one_value_args}" "" ${ARGN}
+    )
+
+    # Ensure that NAME was provided
+    cpp_contains(__at_name_exists __at_NAME "${__at_KEYWORDS_MISSING_VALUES}")
+    if(__at_name_exists)
+        cpp_raise(KeywordMissing "Missing required keyword argument: NAME")
+    endif()
+
+    # Default to the build target list
+    set(__at_tgt_attr "build_targets")
+    if(__at_INSTALLED)
+        set(__at_tgt_attr "installed_targets")
+    endif()
+
+    # Check if a CMaizeTarget with the same name exists already as either
+    # a build or installed target
+    CMaizeProject(check_target "${self}" __at_found "${__at_NAME}" ALL)
+
+    # Determine what to do if a target in the project al
+    if(__at_found)
+        # Exit early if a target with the same name already exists
+        if(NOT __at_OVERWRITE)
+            cpp_return("")
+        endif()
+
+        CMaizeProject(check_target "${self}" __at_build "${__at_NAME}")
+        CMaizeProject(
+            check_target "${self}" __at_install "${__at_NAME}" INSTALLED
+        )
+
+        if(__at_build)
+            CMaizeProject(GET "${self}" __at_tgt_map "build_targets")
+
+            # We cannot easily remove a key from a map, so the best option
+            # is to just clear the value
+            cpp_map(SET "${__at_tgt_map}" "${__at_NAME}" "")
+        endif()
+
+        if (__at_install)
+            CMaizeProject(GET "${self}" __at_tgt_map "installed_targets")
+
+            cpp_map(SET "${__at_tgt_map}" "${__at_NAME}" "")
+        endif()
+    endif()
+
+    # Add the target to the map
+    CMaizeProject(GET "${self}" __at_tgt_map "${__at_tgt_attr}")
+
+    cpp_map(SET "${__at_tgt_map}" "${__at_NAME}" "${__at_target}")
+
+endfunction()

--- a/cmake/cmaize/project/impl_/check_target.cmake
+++ b/cmake/cmaize/project/impl_/check_target.cmake
@@ -1,0 +1,123 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+#[[[
+# Checks if a target with the same name is already added to this project.
+# This defaults to build targets.
+#
+# This internal implementation exists so a required keyword argument is
+# not part of the public interface, as well as to handle both ``desc`` and
+# ``target`` types. Both types are effectively strings representing target
+# names in this algorithm and can be treated equivalently, but cannot be
+# typecast to each other by CMakePPLang. The CMakePPLang type checking
+# is bypassed through the aforementioned required keyword argument for
+# the target name, essentially combining the two types.
+#
+# :param __ct_found: Return variable for whether the target was found.
+# :type __ct_found: bool*
+# :param NAME: Required keyword argument. See description below.
+# :type NAME: desc or target
+# :param **kwargs: Additional keyword arguments may be necessary.
+#
+# :Keyword Arguments:
+#    * **INSTALLED** (*bool*) --
+#      Flag to indicate that the installed targets should be checked.
+#    * **ALL** (*bool*) --
+#      Flag to indicate that both the build and installed targets should
+#      be checked.
+#    * **NAME** (*desc* or *target*) --
+#      Identifying name for a target contained in the current Cmaize
+#      project. This keyword argument is **required**.
+#
+# :returns: CMaizeTarget found (TRUE) or not (FALSE).
+# :rtype: bool
+#]]
+function(_check_target self  __ct_found)
+
+    set(__ct_options INSTALLED ALL)
+    set(__ct_one_value_args NAME)
+    cmake_parse_arguments(
+        __ct "${__ct_options}" "${__ct_one_value_args}" "" ${ARGN}
+    )
+
+    # Ensure that NAME was provided
+    cpp_contains(
+        __ct_name_exists __ct_NAME "${__ct_KEYWORDS_MISSING_VALUES}"
+    )
+    if(__ct_name_exists)
+        cpp_raise(KeywordMissing "Missing required keyword argument: NAME")
+    endif()
+
+    # Default to the build target list
+    set(__ct_tgt_attr "build_targets")
+    if(__ct_ALL)
+        # Search both lists
+        list(APPEND __ct_tgt_attr "installed_targets")
+    elseif(__ct_INSTALLED)
+        set(__ct_tgt_attr "installed_targets")
+    endif()
+
+    foreach(__ct_tgt_attr_i ${__ct_tgt_attr})
+        # Get the collection of targets
+        CMaizeProject(GET "${self}" __ct_tgt_map "${__ct_tgt_attr_i}")
+
+        # We check if the key exists here, but that is not sufficient
+        # to know if the value is valid if the key exists. It is possible
+        # from CMaizeProject(add_target for the key to exist but the value
+        # to be blank since we cannot easily remove keys from a map
+        cpp_map(HAS_KEY "${__ct_tgt_map}" __ct_key_found_i "${__ct_NAME}")
+
+        # Initially, set whether the key was found and whether the target
+        # was found to the same value, but this may change in the check
+        # below
+        set(__ct_found_i "${__ct_key_found_i}")
+
+        # Check if a target with the same name already exists
+        # NOTE: Doesn't work for some reason
+        # cpp_map(HAS_KEY "${__ct_tgt_map}" __ct_found_i "${__ct_NAME}")
+
+        # Additional check if the target key exists in the map to ensure
+        # that the target actually exists
+        if(__ct_key_found_i)
+            cpp_map(GET "${__ct_tgt_map}" __ct_key_value_i "${__ct_NAME}")
+
+            cpp_type_of(__ct_key_value_i_type "${__ct_key_value_i}")
+
+            # Check if the value is implicitly convertible to a CMaizeTarget
+            cpp_implicitly_convertible(
+                __ct_is_target_type "${__ct_key_value_i_type}" CMaizeTarget
+            )
+
+            # If it is convertible to a CMaizeTarget, then the target exists
+            set(__ct_found_i "${__ct_is_target_type}")
+
+            # Unless it is an empty string
+            if("${__ct_key_value_i}" STREQUAL "")
+                set(__ct_found_i FALSE)
+            endif()
+        endif()
+
+        # Return early if target is found
+        if(__ct_found_i)
+            set("${__ct_found}" "${__ct_found_i}")
+            cpp_return("${__ct_found}")
+        endif()
+    endforeach()
+
+    set("${__ct_found}" FALSE)
+    cpp_return("${__ct_found}")
+
+endfunction()

--- a/cmake/cmaize/project/impl_/impl_.cmake
+++ b/cmake/cmaize/project/impl_/impl_.cmake
@@ -1,0 +1,18 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+include(cmaize/project/impl_/add_target)
+include(cmaize/project/impl_/check_target)

--- a/cmake/cmaize/user_api/dependencies/dependencies.cmake
+++ b/cmake/cmaize/user_api/dependencies/dependencies.cmake
@@ -14,11 +14,4 @@
 
 include_guard()
 
-include(cmaize/user_api/add_executable)
-include(cmaize/user_api/add_library)
-include(cmaize/user_api/add_package)
-include(cmaize/user_api/add_tests)
-include(cmaize/user_api/cmaize_option)
-include(cmaize/user_api/cmaize_project)
-include(cmaize/user_api/dependencies/dependencies)
-include(cmaize/user_api/find_or_build_dependency)
+include(cmaize/user_api/dependencies/find_dependency)

--- a/cmake/cmaize/user_api/dependencies/find_dependency.cmake
+++ b/cmake/cmaize/user_api/dependencies/find_dependency.cmake
@@ -1,0 +1,57 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+include(cmaize/user_api/dependencies/impl_/find_dependency)
+
+#[[[
+# Wraps finding a dependency that CMaize can not build.
+#
+# There are some dependencies which are not easily built, or whose build process
+# takes a long time (and thus should be pre-installed). Such dependencies are
+# still needed in build systems, but the build system will not be able to build
+# them if they are not already installed. This function wraps the process of
+# looking for a dependency and aborting the build if an already installed
+# variant of the dependency can not be located.
+#
+# :param name: The name of the dependency we are looking for.
+# :type name: desc
+# :param **kwargs: Keyword arguments describing the behavior of the search. See
+#    the documentation for _fob_parse_arguments for a complete list.
+#
+# :raises UNKNOWN_PM: When ``pm_name`` does not correspond to a known package
+#     manager. Strong throw guarantee.
+#]]
+function(cmaize_find_dependency _cfd_name)
+
+    cpp_get_global(_cfd_project CMAIZE_TOP_PROJECT)
+
+    _find_dependency(
+        _cfd_tgt
+        _cfd_pm
+        _cfd_package_specs
+        "${_cfd_project}"
+        "${_cfd_name}"
+        ${ARGN}
+    )
+
+    if("${_cfd_tgt}" STREQUAL "")
+        cpp_raise(
+            PACKAGE_NOT_FOUND
+            "CMaize was unable to locate ${_cfd_name}"
+        )
+    endif()
+
+endfunction()

--- a/cmake/cmaize/user_api/dependencies/impl_/find_dependency.cmake
+++ b/cmake/cmaize/user_api/dependencies/impl_/find_dependency.cmake
@@ -1,0 +1,76 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+include(cmaize/user_api/dependencies/impl_/get_package_manager)
+include(cmaize/user_api/dependencies/impl_/parse_arguments)
+include(cmaize/package_managers/package_manager)
+
+#[[[
+# Factorization from cmaize_find_dependency and cmaize_find_or_build_dependency.
+#
+# The first part of both cmaize_find_dependency and
+# cmaize_find_or_build_dependency is the same. This function factors that common
+# code out into one function.
+#
+# :param tgt: The variable to hold the target that was found. Will be empty if
+#    no target was found.
+# :type tgt: CMaizeTarget*
+# :param pm: The variable to hold the package manager we looked inside of.
+# :type pm: PackageManager*
+# :param package_specs: The variable to hold the package specification we looked
+#    for.
+# :type package_specs: PackageSpecification*
+# :param project: The CMaize project this find operation is associated with.
+# :type project: CMaizeProject
+# :param name: The name of the dependency we are looking for.
+# :type name: desc
+# :param **kwargs: The arguments to forward to _fob_parse_arguments. See
+#    _fob_parse_arguments documentation for more details.
+#
+# :raises UNKNOWN_PM: When ``pm_name`` does not correspond to a known package
+#     manager. Strong throw guarantee.
+#
+#]]
+function(_find_dependency _fd_tgt _fd_pm _fd_package_specs _fd_project _fd_name)
+
+    _fob_parse_arguments(
+        _fd_package_specs_tmp _fd_pm_name "${_fd_name}" ${ARGN}
+    )
+
+    _fob_get_package_manager(_fd_pm_tmp "${_fd_project}" "${_fd_pm_name}")
+
+    message(STATUS "Attempting to find installed ${_fd_name}")
+
+    # Check if the package is already installed
+    PackageManager(find_installed
+        "${_fd_pm_tmp}" _fd_tgt_tmp "${_fd_package_specs_tmp}" ${ARGN}
+    )
+
+    if(NOT "${_fd_tgt_tmp}" STREQUAL "")
+        message(STATUS "${_fd_name} installation found")
+        message("Adding ${_fd_name} to project")
+        CMaizeProject(add_target
+            "${_fd_project}" "${_fd_name}" "${_fd_tgt_tmp}" INSTALLED
+        )
+        CMaizeProject(check_target "${_fd_project}" was_found "${_fd_name}")
+        message("Sanity check: ${was_found}")
+    endif()
+
+    set("${_fd_tgt}" "${_fd_tgt_tmp}" PARENT_SCOPE)
+    set("${_fd_pm}" "${_fd_pm_tmp}" PARENT_SCOPE)
+    set("${_fd_package_specs}" "${_fd_package_specs_tmp}" PARENT_SCOPE)
+
+endfunction()

--- a/cmake/cmaize/user_api/dependencies/impl_/find_dependency.cmake
+++ b/cmake/cmaize/user_api/dependencies/impl_/find_dependency.cmake
@@ -61,12 +61,10 @@ function(_find_dependency _fd_tgt _fd_pm _fd_package_specs _fd_project _fd_name)
 
     if(NOT "${_fd_tgt_tmp}" STREQUAL "")
         message(STATUS "${_fd_name} installation found")
-        message("Adding ${_fd_name} to project")
         CMaizeProject(add_target
             "${_fd_project}" "${_fd_name}" "${_fd_tgt_tmp}" INSTALLED
         )
-        CMaizeProject(check_target "${_fd_project}" was_found "${_fd_name}")
-        message("Sanity check: ${was_found}")
+        CMaizeProject(check_target "${_fd_project}" was_found "${_fd_name}" INSTALLED)
     endif()
 
     set("${_fd_tgt}" "${_fd_tgt_tmp}" PARENT_SCOPE)

--- a/cmake/cmaize/user_api/dependencies/impl_/get_package_manager.cmake
+++ b/cmake/cmaize/user_api/dependencies/impl_/get_package_manager.cmake
@@ -1,0 +1,64 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+include(cmakepp_lang/cmakepp_lang)
+include(cmaize/project/cmaize_project)
+
+#[[[
+# Wraps the process of retrieving a package manager from a project.
+#
+# At the moment it is somewhat non-trivial to go from a package maanger name,
+# e.g., ``cmake`` or ``pip`` to an actual ``ProjectManager`` object which has
+# been registered with a project. This function wraps that process.
+#
+# :param pm: The variable the package manager will be assigned to.
+# :type pm: PackageManager*
+# :param project: The project that the package manager will be registered with.
+# :type project: CMaizeProject
+# :param pm_name: The name of the package manager to retrieve.
+# :type pm_name: desc
+#
+# :raises UNKNOWN_PM: When ``pm_name`` does not correspond to a known package
+#     manager. Strong throw guarantee.
+#
+#]]
+function(_fob_get_package_manager _gpm_pm _gpm_project _gpm_pm_name)
+
+    if("${_gpm_pm_name}" STREQUAL "cmake")
+        # Enabled by default, no enable function
+    elseif("${_gpm_pm_name}" STREQUAL "pip")
+        enable_pip_package_manager()
+    else()
+        cpp_raise(
+            UNKNOWN_PM "Package manager ${_gpm_pm_name} was not registered."
+        )
+    endif()
+
+    CMaizeProject(
+        get_package_manager "${_gpm_project}" _gpm_pm_tmp "${_gpm_pm_name}"
+    )
+
+    # TODO: This probably can be eliminated if
+    # CMaizeProject(get_package_manager uses get_package_manager_instance
+    # under the hood
+    if("${_gpm_pm_tmp}" STREQUAL "")
+        get_package_manager_instance(_gpm_pm_tmp "${_gpm_pm_name}")
+        CMaizeProject(add_package_manager "${_gpm_project}" "${_gpm_pm_tmp}")
+    endif()
+
+    set("${_gpm_pm}" "${_gpm_pm_tmp}" PARENT_SCOPE)
+
+endfunction()

--- a/cmake/cmaize/user_api/dependencies/impl_/parse_arguments.cmake
+++ b/cmake/cmaize/user_api/dependencies/impl_/parse_arguments.cmake
@@ -1,0 +1,76 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+include(cmaize/project/package_specification)
+
+#[[[
+# Turns "find or build" kwargs into objects.
+#
+# .. note::
+#
+#    The _fob prefix stands for "find or build" and is present to help avoid
+#    name collisions in case another user api function decides it wants a
+#    "parse_arguemnts" function too.
+#
+# TODO: Add more versioning options, such as an ``EXACT`` keyword to allow
+#       the user to specify that only the given version should be found.
+#       As it stands, it finds any version or the exact version if ``VERSION``
+#       is given.
+#       I propose providing the following options: 1) any available version if
+#       no version
+#       keyword is given; 2) the provided version, or greater; or 3) the exact
+#       version if both ``VERSION`` and ``EXACT`` are provided.
+#
+# This function serves as the single source of truth for parsing the kwarg input
+# to functions in the "find_or_build" family.
+#
+# :param package_specs: Variable to hold the resulting package specification
+# :type package_specs: PackageSpecification*
+# :param pm_name: Variable to hold the name of the package manager provided by
+#                 the user. Default package manager is CMake.
+# :type pm_name: desc*
+# :param name: The name of the package
+# :type name: desc
+# :param **kwargs: The keyword arguments this function will parse.
+#
+# :Keyword Arguments:
+#    * **PACKAGE_MANAGER** --
+#      The key associated with the package manager to use.
+#    * **VERSION** (*desc*) --
+#      Version of the package to find. Defaults to no version ("").
+#]]
+function(_fob_parse_arguments _fpa_package_specs _fpa_pm_name _fpa_name)
+
+    set(_fpa_one_value_args PACKAGE_MANAGER VERSION)
+    cmake_parse_arguments(_fpa "" "${_fpa_one_value_args}" "" ${ARGN})
+
+    PackageSpecification(CTOR _fpa_package_specs_tmp)
+    PackageSpecification(SET "${_fpa_package_specs_tmp}" name "${_fpa_name}")
+
+    if(NOT "${_fpa_VERSION}" STREQUAL "")
+        PackageSpecification(
+            SET "${_fpa_package_specs_tmp}" version "${_fpa_VERSION}"
+        )
+    endif()
+
+    if("${_fpa_PACKAGE_MANAGER}" STREQUAL "")
+        set(_fpa_PACKAGE_MANAGER "cmake")
+    endif()
+
+    set("${_fpa_pm_name}" "${_fpa_PACKAGE_MANAGER}" PARENT_SCOPE)
+    set("${_fpa_package_specs}" "${_fpa_package_specs_tmp}" PARENT_SCOPE)
+
+endfunction()

--- a/cmake/cmaize/user_api/find_or_build_dependency.cmake
+++ b/cmake/cmaize/user_api/find_or_build_dependency.cmake
@@ -35,7 +35,7 @@ include(cmaize/user_api/dependencies/impl_/find_dependency)
 function(cmaize_find_or_build_dependency _fobd_name)
 
     cpp_get_global(_fobd_project CMAIZE_TOP_PROJECT)
-    _cmaize_find_dependency(
+    _find_dependency(
         _fobd_tgt
         _fobd_pm
         _fobd_package_specs
@@ -44,14 +44,16 @@ function(cmaize_find_or_build_dependency _fobd_name)
         ${ARGN}
     )
 
-    if(NOT "${_cfd_tgt}" STREQUAL "")
+    # If _fobd_tgt is non-empty we found it!!!
+    if(NOT "${_fobd_tgt}" STREQUAL "")
         cpp_return("")
     endif()
 
-
     message(STATUS "Attempting to fetch and build ${_fobd_name}")
 
-    if("${_fobd_PACKAGE_MANAGER}" STREQUAL "cmake")
+    PackageManager(GET "${_fobd_pm}" _fobd_pm_name type)
+
+    if("${_fobd_pm_name}" STREQUAL "cmake")
         PackageManager(get_package
             "${_fobd_pm}" _fobd_tgt "${_fobd_package_specs}" ${ARGN}
         )
@@ -67,7 +69,7 @@ function(cmaize_find_or_build_dependency _fobd_name)
 
         # Get the build target name for the dependency, since it is not
         # necessarily the same as the name of the CMaize target
-        CMaizeTarget(target "${_fobd_tgt}" _fobdc_build_tgt)
+        CMaizeTarget(target "${_fobd_tgt}" _fobd_build_tgt)
 
         # Create some possible paths where the dependency library will be
         # installed

--- a/tests/cmaize/user_api/dependencies/impl_/test_find_dependency.cmake
+++ b/tests/cmaize/user_api/dependencies/impl_/test_find_dependency.cmake
@@ -62,7 +62,7 @@ function("${_find_dependency}")
         ct_assert_true(are_equal)
 
         # Target should have been added to the project
-        CMaizeProject(check_target "${proj_obj}" cminx_found "cminx")
+        CMaizeProject(check_target "${proj_obj}" cminx_found "cminx" INSTALLED)
         ct_assert_true(cminx_found)
 
     endfunction()

--- a/tests/cmaize/user_api/dependencies/impl_/test_find_dependency.cmake
+++ b/tests/cmaize/user_api/dependencies/impl_/test_find_dependency.cmake
@@ -1,0 +1,99 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(cmake_test/cmake_test)
+include(cmaize/user_api/cmaize_project)
+include(cmaize/user_api/dependencies/impl_/find_dependency)
+include(cmaize/utilities/python)
+
+ct_add_test(NAME "_find_dependency")
+function("${_find_dependency}")
+
+    # Create a project
+    set(proj_name "test_find_dependency")
+    project("${proj_name}")
+    cmaize_project("${proj_name}")
+    cpp_get_global(proj_obj CMAIZE_TOP_PROJECT)
+
+    find_python(py_exe py_version)
+    create_virtual_env(
+        venv_dir "${py_exe}" "${CMAKE_BINARY_DIR}" "${_find_dependency}"
+    )
+
+    # Make sure everything is using the venv Python
+    set(Python3_EXECUTABLE "${venv_dir}/bin/python3")
+
+    # The corr package manager
+    _fob_get_package_manager(pm_corr "${proj_obj}" "pip")
+
+    ct_add_section(NAME "find_installed_package")
+    function("${find_installed_package}")
+
+        # Create the specification for CMinx
+        PackageSpecification(CTOR cminx_corr)
+        PackageSpecification(SET "${cminx_corr}" name "cminx")
+
+        # Install CMinx
+        PackageManager(install_package "${pm_corr}" "${cminx_corr}")
+
+        # Look for CMinx
+        _find_dependency(
+            cminx_tgt pm cminx "${proj_obj}" "cminx" PACKAGE_MANAGER pip
+        )
+
+        # Should get back a target since if it was found
+        ct_assert_not_equal(cminx_tgt "")
+
+        PackageManager(EQUAL "${pm_corr}" are_equal "${pm}")
+        ct_assert_true(are_equal)
+
+        PackageSpecification(EQUAL "${cminx_corr}" are_equal "${cminx}")
+        ct_assert_true(are_equal)
+
+        # Target should have been added to the project
+        CMaizeProject(check_target "${proj_obj}" cminx_found "cminx")
+        ct_assert_true(cminx_found)
+
+    endfunction()
+
+
+    ct_add_section(NAME "find_not_installed_package")
+    function("${find_not_installed_package}")
+
+        _find_dependency(
+            not_real_tgt
+            pm
+            not_real
+            "${proj_obj}"
+            "not_real"
+            VERSION 1.0.0
+            PACKAGE_MANAGER pip
+        )
+
+        ct_assert_equal(not_real_tgt "")
+
+        PackageManager(EQUAL "${pm_corr}" are_equal "${pm}")
+        ct_assert_true(are_equal)
+
+        # This is the package spec that should have been made
+        PackageSpecification(CTOR not_real_corr)
+        PackageSpecification(SET "${not_real_corr}" name "not_real")
+        PackageSpecification(SET "${not_real_corr}" version "1.0.0")
+
+
+        PackageSpecification(EQUAL "${not_real_corr}" are_equal "${not_real}")
+        ct_assert_true(are_equal)
+
+    endfunction()
+endfunction()

--- a/tests/cmaize/user_api/dependencies/impl_/test_get_package_manager.cmake
+++ b/tests/cmaize/user_api/dependencies/impl_/test_get_package_manager.cmake
@@ -1,0 +1,54 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(cmake_test/cmake_test)
+include(cmaize/user_api/cmaize_project)
+include(cmaize/user_api/dependencies/impl_/get_package_manager)
+
+
+ct_add_test(NAME "_fob_get_package_manager")
+function("${_fob_get_package_manager}")
+
+    ct_add_section(NAME "throws_if_invalid_name" EXPECTFAIL)
+    function("${throws_if_invalid_name}")
+
+        set(proj_name "test_fob_get_package_manager_throws_if_invalid_name")
+        project("${proj_name}")
+        cmaize_project("${proj_name}")
+        cpp_get_global(proj_obj CMAIZE_TOP_PROJECT)
+
+        _fob_get_package_manager(pm "${proj_obj}" "not_a_pm")
+
+    endfunction()
+
+    foreach(pm_name cmake pip)
+
+        ct_add_section(NAME "get_${pm_name}")
+        function("${get_${pm_name}}")
+
+            set(proj_name "test_fob_get_package_manager_get_${pm_name}")
+            project("${proj_name}")
+            cmaize_project("${proj_name}")
+            cpp_get_global(proj_obj CMAIZE_TOP_PROJECT)
+
+            _fob_get_package_manager(pm "${proj_obj}" "${pm_name}")
+
+            CMaizeProject(get_package_manager "${proj_obj}" corr "${pm_name}")
+            PackageManager(EQUAL "${corr}" are_equal "${pm}")
+            ct_assert_true(are_equal)
+
+        endfunction()
+    endforeach()
+
+endfunction()

--- a/tests/cmaize/user_api/dependencies/impl_/test_parse_arguments.cmake
+++ b/tests/cmaize/user_api/dependencies/impl_/test_parse_arguments.cmake
@@ -1,0 +1,62 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(cmake_test/cmake_test)
+include(cmaize/user_api/dependencies/impl_/parse_arguments)
+
+ct_add_test(NAME "_fob_parse_arguments")
+function("${_fob_parse_arguments}")
+
+    # All of these tests return the same base PackageSpec
+    PackageSpecification(CTOR corr)
+    PackageSpecification(SET "${corr}" name cminx)
+
+    ct_add_section(NAME "no_extra_args")
+    function("${no_extra_args}")
+
+        _fob_parse_arguments(pkg_specs pm_name cminx)
+
+        PackageSpecification(EQUAL "${corr}" are_equal "${pkg_specs}")
+        ct_assert_true(are_equal)
+
+        ct_assert_equal(pm_name "cmake")
+
+    endfunction()
+
+    ct_add_section(NAME "pass_PACKAGE_MANAGER")
+    function("${pass_PACKAGE_MANAGER}")
+
+        _fob_parse_arguments(pkg_specs pm_name cminx PACKAGE_MANAGER pip)
+
+        PackageSpecification(EQUAL "${corr}" are_equal "${pkg_specs}")
+        ct_assert_true(are_equal)
+
+        ct_assert_equal(pm_name "pip")
+
+    endfunction()
+
+
+    ct_add_section(NAME "pass_VERSION")
+    function("${pass_VERSION}")
+
+        _fob_parse_arguments(pkg_specs pm_name cminx VERSION 1.1.1)
+
+        PackageSpecification(SET "${corr}" version "1.1.1")
+        PackageSpecification(EQUAL "${corr}" are_equal "${pkg_specs}")
+        ct_assert_true(are_equal)
+
+        ct_assert_equal(pm_name "cmake")
+    endfunction()
+
+endfunction()

--- a/tests/cmaize/user_api/dependencies/test_find_dependency.cmake
+++ b/tests/cmaize/user_api/dependencies/test_find_dependency.cmake
@@ -1,0 +1,65 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(cmake_test/cmake_test)
+include(cmaize/user_api/cmaize_project)
+include(cmaize/user_api/dependencies/find_dependency)
+include(cmaize/user_api/dependencies/impl_/get_package_manager)
+include(cmaize/utilities/python)
+
+ct_add_test(NAME "cmaize_find_dependency")
+function("${cmaize_find_dependency}")
+
+    # Create a project
+    set(proj_name "test_find_dependency")
+    project("${proj_name}")
+    cmaize_project("${proj_name}")
+    cpp_get_global(proj_obj CMAIZE_TOP_PROJECT)
+
+    find_python(py_exe py_version)
+    create_virtual_env(
+        venv_dir "${py_exe}" "${CMAKE_BINARY_DIR}" "${_find_dependency}"
+    )
+
+    # Make sure everything is using the venv Python
+    set(Python3_EXECUTABLE "${venv_dir}/bin/python3")
+
+    ct_add_section(NAME "find_installed_package")
+    function("${find_installed_package}")
+
+        # Create the specification for CMinx
+        PackageSpecification(CTOR cminx_corr)
+        PackageSpecification(SET "${cminx_corr}" name "cminx")
+
+        # Install CMinx
+        _fob_get_package_manager(pm "${proj_obj}" "pip")
+        PackageManager(install_package "${pm}" "${cminx_corr}")
+
+        # Look for CMinx
+        cmaize_find_dependency("cminx" PACKAGE_MANAGER pip)
+
+        # Should have added a target to the project
+        CMaizeProject(check_target "${proj_obj}" cminx_found "cminx")
+        ct_assert_true(cminx_found)
+
+    endfunction()
+
+
+    ct_add_section(NAME "find_not_installed_package" EXPECTFAIL)
+    function("${find_not_installed_package}")
+
+        cmaize_find_dependency("not_real" PACKAGE_MANAGER pip)
+
+    endfunction()
+endfunction()

--- a/tests/cmaize/user_api/dependencies/test_find_dependency.cmake
+++ b/tests/cmaize/user_api/dependencies/test_find_dependency.cmake
@@ -29,7 +29,7 @@ function("${cmaize_find_dependency}")
 
     find_python(py_exe py_version)
     create_virtual_env(
-        venv_dir "${py_exe}" "${CMAKE_BINARY_DIR}" "${_find_dependency}"
+        venv_dir "${py_exe}" "${CMAKE_BINARY_DIR}" "${cmaize_find_dependency}"
     )
 
     # Make sure everything is using the venv Python

--- a/tests/cmaize/user_api/dependencies/test_find_dependency.cmake
+++ b/tests/cmaize/user_api/dependencies/test_find_dependency.cmake
@@ -50,7 +50,7 @@ function("${cmaize_find_dependency}")
         cmaize_find_dependency("cminx" PACKAGE_MANAGER pip)
 
         # Should have added a target to the project
-        CMaizeProject(check_target "${proj_obj}" cminx_found "cminx")
+        CMaizeProject(check_target "${proj_obj}" cminx_found "cminx" INSTALLED)
         ct_assert_true(cminx_found)
 
     endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
This PR adds a function similar to `find_or_build_dependency`, but it will crash the build if the dependency is not found (as opposed to building it).

**TODOs**
- [x] The tests are failing because something's wrong in the `_find_dependency` function.