### PR TITLE
add cmaize prefix

### DIFF
--- a/cmake/cmaize/user_api/dependencies/find_dependency.cmake
+++ b/cmake/cmaize/user_api/dependencies/find_dependency.cmake
@@ -38,7 +38,7 @@ function(cmaize_find_dependency _cfd_name)
 
     cpp_get_global(_cfd_project CMAIZE_TOP_PROJECT)
 
-    _find_dependency(
+    _cmaize_find_dependency(
         _cfd_tgt
         _cfd_pm
         _cfd_package_specs

--- a/cmake/cmaize/user_api/dependencies/find_or_build_dependency.cmake
+++ b/cmake/cmaize/user_api/dependencies/find_or_build_dependency.cmake
@@ -35,7 +35,7 @@ include(cmaize/user_api/dependencies/impl_/find_dependency)
 function(cmaize_find_or_build_dependency _fobd_name)
 
     cpp_get_global(_fobd_project CMAIZE_TOP_PROJECT)
-    _find_dependency(
+    _cmaize_find_dependency(
         _fobd_tgt
         _fobd_pm
         _fobd_package_specs

--- a/cmake/cmaize/user_api/dependencies/impl_/find_dependency.cmake
+++ b/cmake/cmaize/user_api/dependencies/impl_/find_dependency.cmake
@@ -44,7 +44,7 @@ include(cmaize/package_managers/package_manager)
 #     manager. Strong throw guarantee.
 #
 #]]
-function(_find_dependency _fd_tgt _fd_pm _fd_package_specs _fd_project _fd_name)
+function(_cmaize_find_dependency _fd_tgt _fd_pm _fd_package_specs _fd_project _fd_name)
 
     _fob_parse_arguments(
         _fd_package_specs_tmp _fd_pm_name "${_fd_name}" ${ARGN}

--- a/tests/cmaize/user_api/dependencies/impl_/test_find_dependency.cmake
+++ b/tests/cmaize/user_api/dependencies/impl_/test_find_dependency.cmake
@@ -17,18 +17,18 @@ include(cmaize/user_api/cmaize_project)
 include(cmaize/user_api/dependencies/impl_/find_dependency)
 include(cmaize/utilities/python)
 
-ct_add_test(NAME "_find_dependency")
-function("${_find_dependency}")
+ct_add_test(NAME "_cmaize_find_dependency")
+function("${_cmaize_find_dependency}")
 
     # Create a project
-    set(proj_name "test_find_dependency")
+    set(proj_name "test_cmaize_find_dependency")
     project("${proj_name}")
     cmaize_project("${proj_name}")
     cpp_get_global(proj_obj CMAIZE_TOP_PROJECT)
 
     find_python(py_exe py_version)
     create_virtual_env(
-        venv_dir "${py_exe}" "${CMAKE_BINARY_DIR}" "${_find_dependency}"
+        venv_dir "${py_exe}" "${CMAKE_BINARY_DIR}" "${_cmaize_find_dependency}"
     )
 
     # Make sure everything is using the venv Python
@@ -48,7 +48,7 @@ function("${_find_dependency}")
         PackageManager(install_package "${pm_corr}" "${cminx_corr}")
 
         # Look for CMinx
-        _find_dependency(
+        _cmaize_find_dependency(
             cminx_tgt pm cminx "${proj_obj}" "cminx" PACKAGE_MANAGER pip
         )
 
@@ -71,7 +71,7 @@ function("${_find_dependency}")
     ct_add_section(NAME "find_not_installed_package")
     function("${find_not_installed_package}")
 
-        _find_dependency(
+        _cmaize_find_dependency(
             not_real_tgt
             pm
             not_real


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Apparently CMake's `find_package` also defines a function `_find_dependency`. This PR simply renames our `_find_dependency` function to `_cmaize_find_dependency`.

**TODOs**
None. r2g.
