### PR TITLE
CXX Standard bug

### DIFF
--- a/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
+++ b/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
@@ -51,13 +51,13 @@ endif()")
 # Create imported target ${__gtc_namespace}${__gtc_target_name}
 add_library(${__gtc_namespace}${__gtc_target_name} SHARED IMPORTED)
 
-set(__gtc_compile_features \"\")
 if(NOT \"${__gtc_cxx_std}\" STREQUAL \"\")
-    set(__gtc_compile_features \"INTERFACE_COMPILE_FEATURES cxx_std_${__gtc_cxx_std}\")
+    set_target_properties(${__gtc_namespace}${__gtc_target_name} PROPERTIES
+        INTERFACE_COMPILE_FEATURES \"cxx_std_${__gtc_cxx_std}\"
+    )
 endif()
 
 set_target_properties(${__gtc_namespace}${__gtc_target_name} PROPERTIES
-\${__gtc_compile_features}
 INTERFACE_INCLUDE_DIRECTORIES \"\${PACKAGE_PREFIX_DIR}/include\"
 INTERFACE_LINK_LIBRARIES "
     )

--- a/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
+++ b/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
@@ -53,7 +53,7 @@ add_library(${__gtc_namespace}${__gtc_target_name} SHARED IMPORTED)
 
 set(__gtc_compile_features \"\")
 if(NOT \"${__gtc_cxx_std}\" STREQUAL \"\")
-    set(__gtc_compile_features \"INTERFACE_COMPILE_FEATURES cxx_std_${__gtc_xx_std}\")
+    set(__gtc_compile_features \"INTERFACE_COMPILE_FEATURES cxx_std_${__gtc_cxx_std}\")
 endif()
 
 set_target_properties(${__gtc_namespace}${__gtc_target_name} PROPERTIES

--- a/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
+++ b/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
@@ -51,8 +51,13 @@ endif()")
 # Create imported target ${__gtc_namespace}${__gtc_target_name}
 add_library(${__gtc_namespace}${__gtc_target_name} SHARED IMPORTED)
 
+set(__gtc_compile_features "")
+if(NOT "${__gtc_cxx_std}" STREQUAL "")
+    set(__gtc_compile_features "INTERFACE_COMPILE_FEATURES cxx_std_${__gtc_xx_std}")
+endif()
+
 set_target_properties(${__gtc_namespace}${__gtc_target_name} PROPERTIES
-INTERFACE_COMPILE_FEATURES \"cxx_std_${__gtc_cxx_std}\"
+${__gtc_compile_features}
 INTERFACE_INCLUDE_DIRECTORIES \"\${PACKAGE_PREFIX_DIR}/include\"
 INTERFACE_LINK_LIBRARIES "
     )

--- a/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
+++ b/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
@@ -57,7 +57,7 @@ if(NOT \"${__gtc_cxx_std}\" STREQUAL \"\")
 endif()
 
 set_target_properties(${__gtc_namespace}${__gtc_target_name} PROPERTIES
-${__gtc_compile_features}
+\${__gtc_compile_features}
 INTERFACE_INCLUDE_DIRECTORIES \"\${PACKAGE_PREFIX_DIR}/include\"
 INTERFACE_LINK_LIBRARIES "
     )

--- a/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
+++ b/cmake/cmaize/package_managers/cmake/impl_/generate_target_config.cmake
@@ -51,9 +51,9 @@ endif()")
 # Create imported target ${__gtc_namespace}${__gtc_target_name}
 add_library(${__gtc_namespace}${__gtc_target_name} SHARED IMPORTED)
 
-set(__gtc_compile_features "")
-if(NOT "${__gtc_cxx_std}" STREQUAL "")
-    set(__gtc_compile_features "INTERFACE_COMPILE_FEATURES cxx_std_${__gtc_xx_std}")
+set(__gtc_compile_features \"\")
+if(NOT \"${__gtc_cxx_std}\" STREQUAL \"\")
+    set(__gtc_compile_features \"INTERFACE_COMPILE_FEATURES cxx_std_${__gtc_xx_std}\")
 endif()
 
 set_target_properties(${__gtc_namespace}${__gtc_target_name} PROPERTIES


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
If the C++ standard isn't set when packaging files are generated the generated file will be incorrect.

**TODOs**
Verify it fixes the problem.
