### PR TITLE
Fixes ChemCache #78

### DIFF
--- a/cmake/cmaize/user_api/cmaize_option.cmake
+++ b/cmake/cmaize/user_api/cmaize_option.cmake
@@ -58,7 +58,7 @@ function(cmaize_option _co_name _co_default_value _co_docstring)
 
     # A set CMake variable (this includes CMake's cache) takes precedence over
     # all else
-    if(DEFINED "${_co_name}")
+    if(DEFINED "${_co_name}" AND DEFINED "${${_co_name}}")
         CMaizeProject(
             set_config_option "${_co_project}" "${_co_name}" "${${_co_name}}"
         )

--- a/cmake/cmaize/user_api/cmaize_option.cmake
+++ b/cmake/cmaize/user_api/cmaize_option.cmake
@@ -58,7 +58,7 @@ function(cmaize_option _co_name _co_default_value _co_docstring)
 
     # A set CMake variable (this includes CMake's cache) takes precedence over
     # all else
-    if(DEFINED "${_co_name}" AND DEFINED "${${_co_name}}")
+    if((DEFINED "${_co_name}") AND (NOT "${${_co_name}}" STREQUAL ""))
         CMaizeProject(
             set_config_option "${_co_project}" "${_co_name}" "${${_co_name}}"
         )


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
This error was found in NWChemEx/ChemCache#78

**Description**
When trying to prioritize CMake variables over inputs to `cmaize_option` we only checked if a
variable was defined, not whether it was set to a value. This adds the check for a value.

**TODOs**
None R2g.