### PR TITLE
fix problem with pre-installed depends

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,23 +29,23 @@ jobs:
         with:
           cmakeVersion: ${{ env.cmake_version }}
 
-      #- name: Download Catch2
-      #  run: |
-      #    git clone https://github.com/catchorg/Catch2.git catch2 \
-      #      --branch v3.4.0
+      - name: Download Catch2
+        run: |
+          git clone https://github.com/catchorg/Catch2.git catch2 \
+            --branch v3.4.0
 
-      #- name: Build Catch2
-      #  run: |
-      #    prefix=`pwd`/catch2_install
-      #    cd catch2
-      #    cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX="${prefix}"
-      #    cmake --build build --parallel 2
-      #    echo "CMAKE_PREFIX_PATH=${prefix}" >> $GITHUB_ENV
+      - name: Build Catch2
+        run: |
+          prefix=`pwd`/catch2_install
+          cd catch2
+          cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX="${prefix}"
+          cmake --build build --parallel 2
+          echo "CMAKE_PREFIX_PATH=${prefix}" >> $GITHUB_ENV
 
-      #- name: Install Catch2
-      #  run: |
-      #    cd catch2
-      #    cmake --build build --target install
+      - name: Install Catch2
+        run: |
+          cd catch2
+          cmake --build build --target install
 
       - name: Configure Project
         run: >

--- a/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
+++ b/cmake/cmaize/package_managers/cmake/cmake_package_manager.cmake
@@ -127,13 +127,23 @@ cpp_class(CMakePackageManager PackageManager)
 
         CMakePackageManager(GET "${self}" _rd_dependencies dependencies)
         cpp_map(GET "${_rd_dependencies}" _rd_depend "${_rd_pkg_name}")
+        cpp_map(KEYS "${_rd_dependencies}" _rd_keys)
+        foreach(_rd_key ${_rd_keys})
+            cpp_map(GET "${_rd_dependencies}" _rd_temp "${_rd_key}")
+            message("${_rd_key} = ${_rd_temp}")
+        endforeach()
+
+
+        message("PackageManager had ${_rd_pkg_name} = ${_rd_depend}")
         if("${_rd_depend}" STREQUAL "")
             message(DEBUG "Registering dependency to package manager: ${_rd_pkg_name}")
 
             set(_rd_depend "")
             if("${ARGN}" MATCHES "github")
+                message("Creating a GitHub dependency")
                 GitHubDependency(CTOR _rd_depend)
             else()
+                message("Creating a non-GitHub dependency")
                 RemoteURLDependency(CTOR _rd_depend)
             endif()
 
@@ -181,6 +191,8 @@ cpp_class(CMakePackageManager PackageManager)
         )
 
         PackageSpecification(GET "${_fi_package_specs}" _fi_pkg_name name)
+
+        message("Looking for ${_fi_pkg_name}")
 
         CMakePackageManager(register_dependency
             "${self}"

--- a/cmake/cmaize/package_managers/cmake/dependency/dependency_class.cmake
+++ b/cmake/cmaize/package_managers/cmake/dependency/dependency_class.cmake
@@ -102,6 +102,7 @@ cpp_class(Dependency)
 
         # Check if it was already found? If so short-circuit and return TRUE
         Dependency(GET "${self}" "${_fd_found}" found)
+        message("Was already found? ${${_fd_found}}")
         if("${${_fd_found}}")
             cpp_return("${_fd_found}")
         endif()
@@ -202,4 +203,3 @@ cpp_class(Dependency)
     endfunction()
 
 cpp_end_class()
-


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Apparently my attempt to factor out setting/unsetting CMake's cache broke things that depend on the Cache. This PR undoes the factoring.

**TODOs**
None. R2g assuming it passes CI.
