### PR TITLE
Fix failing test for CMake 4

### DIFF
--- a/docs/src/background/redundancy.rst
+++ b/docs/src/background/redundancy.rst
@@ -60,7 +60,7 @@ then the minimal ``CMakeLists.txt`` file looks like:
 
 .. literalinclude:: /../../tests/docs/bare_bones_cmake/CMakeLists.txt
    :language: CMake
-   :lines: 15
+   :lines: 18-20
    :linenos:
    :lineno-start: 1
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,5 +13,10 @@ include(cmake_test/cmake_test)
 
 set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
 
-ct_add_dir("cmaize" USE_REL_PATH_NAMES)
+ct_add_dir(
+    "cmaize"
+    USE_REL_PATH_NAMES
+    CMAKE_OPTIONS
+        -DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE
+)
 add_subdirectory(docs)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,5 @@ include(cmake_test/cmake_test)
 
 set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
 
-# ct_add_dir("cpp")
-ct_add_dir("cmaize")
+ct_add_dir("cmaize" USE_REL_PATH_NAMES)
 add_subdirectory(docs)

--- a/tests/docs/bare_bones_cmake/CMakeLists.txt
+++ b/tests/docs/bare_bones_cmake/CMakeLists.txt
@@ -15,7 +15,7 @@
 # Minimum version required as of CMake 4.0
 # (see https://cmake.org/cmake/help/latest/policy/CMP0000.html).
 # Match this with minimum version from 'CMaize/CMakeLists.txt'.
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.5)  # Required as of CMake 4.0
 
 add_executable(hello_world hello_world.cpp)
 

--- a/tests/docs/bare_bones_cmake/CMakeLists.txt
+++ b/tests/docs/bare_bones_cmake/CMakeLists.txt
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Minimum version required as of CMake 4.0
+# (see https://cmake.org/cmake/help/latest/policy/CMP0000.html).
+# Match this with minimum version from 'CMaize/CMakeLists.txt'.
+cmake_minimum_required(VERSION 3.19)
+
 add_executable(hello_world hello_world.cpp)
 
 # The below lines of code are used in unit testing this code example


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #168.

**Description**
Updates the `tests/docs/bare_bones_cmake` test to include a minimum CMake version, since it is required since CMake 4. Also updates the documentation referencing this code to ensure it uses the correct lines.

I also performed a bit of testing cleanup/updates that have been sitting in my local repo for a while.
1. Make CMaize use the CMakeTest feature for relative paths for test names.
2. Default `CMAKE_MESSAGE_LOG_LEVEL` to `VERBOSE` for testing. The reasoning is that you will only see the text when a test is failing, and when a test is failing, you will want verbose information about what happened to determine why it is failing.
