### PR TITLE
Update CI to Test CMake 4.x

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cmake: [3.19.7, latestrc]
+        # [minimum version, latest stable, latest release candidate]
+        cmake: [3.19.7, install, installrc]
 
     env:
       cmake_version: ${{ matrix.cmake }}
       cores: 2
-      os: linux-x86_64
 
     steps:
       - name: Checkout repository
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build Catch2
         run: |
-          prefix=`pwd`/catch2_install
+          prefix=$PWD/catch2_install
           cd catch2
           cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX="${prefix}"
           cmake --build build --parallel 2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # [minimum version, latest stable, latest release candidate]
-        cmake: [3.19.7, install, installrc]
+        cmake: [3.19.7, 3.31.9, install, installrc]
 
     env:
       cmake_version: ${{ matrix.cmake }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,11 +14,12 @@ jobs:
     strategy:
       matrix:
         # [minimum version, latest stable, latest release candidate]
-        cmake: [3.19.7, 3.31.9, install, installrc]
+        cmake: [3.19.7, 3.31.9, latest, latestrc]
 
     env:
       cmake_version: ${{ matrix.cmake }}
       cores: 2
+      os: linux-x86_64
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -13,33 +13,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cmake: [3.19.7, 3.22.4, 3.23.1]
+        # [minimum version, last 3.x, latest stable, latest release candidate]
+        cmake: [3.19.7, 3.31.9, install, installrc]
 
     env:
       cmake_version: ${{ matrix.cmake }}
-      os: linux-x86_64
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-      - name: get cmake
-        env:
-          url_prefix: https://github.com/Kitware/CMake/releases/download
+      - name: Get CMake and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: ${{ env.cmake_version }}
+
+      - name: Configure Project
         run: |
-          cmake_prefix=cmake-${cmake_version}-${os}
-          cmake_script=${cmake_prefix}.sh
-          wget "${url_prefix}/v${cmake_version}/${cmake_script}"
-          mkdir -p ./${cmake_prefix}
-          /bin/sh "${cmake_script}" --prefix=./${cmake_prefix} --exclude-subdir
+          cmake -H. -Bbuild -DBUILD_TESTING=ON
 
-      - name: configure
-        run: |
-          cmake-${cmake_version}-${os}/bin/cmake -H. -Bbuild -DBUILD_TESTING=ON
-
-      - name: unit_test
+      - name: Unit Tests
         run: |
           cd build
-          ../cmake-${cmake_version}-${os}/bin/ctest \
+          ctest \
               j 2 \
               --output-on-failure \
               -LE integration_tests

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -14,10 +14,11 @@ jobs:
     strategy:
       matrix:
         # [minimum version, last 3.x, latest stable, latest release candidate]
-        cmake: [3.19.7, 3.31.9, install, installrc]
+        cmake: [3.19.7, 3.31.9, latest, latestrc]
 
     env:
       cmake_version: ${{ matrix.cmake }}
+      os: linux-x86_64
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
None.

**Description**
CMake versions that we test do not include CMake 4.x, so both the latest stable and release candidate versions of CMake are added for unit tests. The integration tests already test the latest release candidate, but don't use the most up to date syntax from [lukka/get-cmake](https://github.com/lukka/get-cmake). The integration tests and unit tests should now test all of the same CMake versions.

This PR also simplifies the unit testing CI by using the [lukka/get-cmake](https://github.com/lukka/get-cmake) action instead of manually installing CMake.

**TODOs**
- [x] Ensure this actually runs on a GitHub runner.
